### PR TITLE
feat: added symbolic image resolver

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sitepark/atoolo-search-bundle.git",
-                "reference": "e21b87280cb1ece60ea2509ceaee5a316aeade95"
+                "reference": "473ff6dc30721fd7a0fcbe701affe0135cb277e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sitepark/atoolo-search-bundle/zipball/e21b87280cb1ece60ea2509ceaee5a316aeade95",
-                "reference": "e21b87280cb1ece60ea2509ceaee5a316aeade95",
+                "url": "https://api.github.com/repos/sitepark/atoolo-search-bundle/zipball/473ff6dc30721fd7a0fcbe701affe0135cb277e3",
+                "reference": "473ff6dc30721fd7a0fcbe701affe0135cb277e3",
                 "shasum": ""
             },
             "require": {
@@ -86,7 +86,7 @@
                 "symfony/config": "^6.3 || ^7.0",
                 "symfony/console": "^6.3 || ^7.0",
                 "symfony/dependency-injection": "^6.3 || ^7.0",
-                "symfony/dotenv": "^7.0",
+                "symfony/dotenv": "^6.3 || ^7.0",
                 "symfony/event-dispatcher": "^6.3 || ^7.0",
                 "symfony/finder": "^6.3 || ^7.0",
                 "symfony/http-kernel": "^6.3 || ^7.0",
@@ -131,7 +131,7 @@
                 "issues": "https://github.com/sitepark/atoolo-search-bundle/issues",
                 "source": "https://github.com/sitepark/atoolo-search-bundle/tree/main"
             },
-            "time": "2024-05-27T07:49:57+00:00"
+            "time": "2024-06-04T11:38:30+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -560,16 +560,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.29.0",
+            "version": "1.29.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "536889f2b340489d328f5ffb7b02bb6b183ddedc"
+                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/536889f2b340489d328f5ffb7b02bb6b183ddedc",
-                "reference": "536889f2b340489d328f5ffb7b02bb6b183ddedc",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fcaefacf2d5c417e928405b71b400d4ce10daaf4",
+                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4",
                 "shasum": ""
             },
             "require": {
@@ -601,9 +601,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.1"
             },
-            "time": "2024-05-06T12:04:23+00:00"
+            "time": "2024-05-31T08:52:43+00:00"
         },
         {
             "name": "psr/cache",
@@ -1037,16 +1037,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "48e3508338987d63b0114a00c208c4cbb76e5303"
+                "reference": "760294dc7158372699dccd077965c16c328f8719"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/48e3508338987d63b0114a00c208c4cbb76e5303",
-                "reference": "48e3508338987d63b0114a00c208c4cbb76e5303",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/760294dc7158372699dccd077965c16c328f8719",
+                "reference": "760294dc7158372699dccd077965c16c328f8719",
                 "shasum": ""
             },
             "require": {
@@ -1054,6 +1054,7 @@
                 "psr/cache": "^2.0|^3.0",
                 "psr/log": "^1.1|^2|^3",
                 "symfony/cache-contracts": "^2.5|^3",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
                 "symfony/service-contracts": "^2.5|^3",
                 "symfony/var-exporter": "^6.4|^7.0"
             },
@@ -1113,7 +1114,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v7.0.7"
+                "source": "https://github.com/symfony/cache/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -1129,7 +1130,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -1209,22 +1210,22 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "f66f908a975500aa4594258bf454dc66e3939eac"
+                "reference": "2210fc99fa42a259eb6c89d1f724ce0c4d62d5d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/f66f908a975500aa4594258bf454dc66e3939eac",
-                "reference": "f66f908a975500aa4594258bf454dc66e3939eac",
+                "url": "https://api.github.com/repos/symfony/config/zipball/2210fc99fa42a259eb6c89d1f724ce0c4d62d5d2",
+                "reference": "2210fc99fa42a259eb6c89d1f724ce0c4d62d5d2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/filesystem": "^6.4|^7.0",
+                "symfony/filesystem": "^7.1",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
@@ -1264,7 +1265,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.0.7"
+                "source": "https://github.com/symfony/config/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -1280,20 +1281,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c981e0e9380ce9f146416bde3150c79197ce9986"
+                "reference": "9b008f2d7b21c74ef4d0c3de6077a642bc55ece3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c981e0e9380ce9f146416bde3150c79197ce9986",
-                "reference": "c981e0e9380ce9f146416bde3150c79197ce9986",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9b008f2d7b21c74ef4d0c3de6077a642bc55ece3",
+                "reference": "9b008f2d7b21c74ef4d0c3de6077a642bc55ece3",
                 "shasum": ""
             },
             "require": {
@@ -1357,7 +1358,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.0.7"
+                "source": "https://github.com/symfony/console/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -1373,27 +1374,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "4db1314337f4dd864113f88e08c9a7f98b1c1324"
+                "reference": "77c636dfd86c0b60c5d184b2fd2ddf8dd11c309c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/4db1314337f4dd864113f88e08c9a7f98b1c1324",
-                "reference": "4db1314337f4dd864113f88e08c9a7f98b1c1324",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/77c636dfd86c0b60c5d184b2fd2ddf8dd11c309c",
+                "reference": "77c636dfd86c0b60c5d184b2fd2ddf8dd11c309c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/service-contracts": "^3.3",
+                "symfony/service-contracts": "^3.5",
                 "symfony/var-exporter": "^6.4|^7.0"
             },
             "conflict": {
@@ -1437,7 +1438,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.0.7"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -1453,7 +1454,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1524,16 +1525,16 @@
         },
         {
             "name": "symfony/dotenv",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "0fd573c141e1990848702d56329050efd5bf25cc"
+                "reference": "efa715ec40c098f2fba62444f4fd75d0d4248ede"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/0fd573c141e1990848702d56329050efd5bf25cc",
-                "reference": "0fd573c141e1990848702d56329050efd5bf25cc",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/efa715ec40c098f2fba62444f4fd75d0d4248ede",
+                "reference": "efa715ec40c098f2fba62444f4fd75d0d4248ede",
                 "shasum": ""
             },
             "require": {
@@ -1578,7 +1579,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v7.0.7"
+                "source": "https://github.com/symfony/dotenv/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -1594,20 +1595,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "cf97429887e40480c847bfeb6c3991e1e2c086ab"
+                "reference": "e9b8bbce0b4f322939332ab7b6b81d8c11da27dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/cf97429887e40480c847bfeb6c3991e1e2c086ab",
-                "reference": "cf97429887e40480c847bfeb6c3991e1e2c086ab",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/e9b8bbce0b4f322939332ab7b6b81d8c11da27dd",
+                "reference": "e9b8bbce0b4f322939332ab7b6b81d8c11da27dd",
                 "shasum": ""
             },
             "require": {
@@ -1653,7 +1654,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.0.7"
+                "source": "https://github.com/symfony/error-handler/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -1669,20 +1670,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "db2a7fab994d67d92356bb39c367db115d9d30f9"
+                "reference": "9fa7f7a21beb22a39a8f3f28618b29e50d7a55a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/db2a7fab994d67d92356bb39c367db115d9d30f9",
-                "reference": "db2a7fab994d67d92356bb39c367db115d9d30f9",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/9fa7f7a21beb22a39a8f3f28618b29e50d7a55a7",
+                "reference": "9fa7f7a21beb22a39a8f3f28618b29e50d7a55a7",
                 "shasum": ""
             },
             "require": {
@@ -1733,7 +1734,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.0.7"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -1749,7 +1750,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -1829,21 +1830,22 @@
         },
         {
             "name": "symfony/expression-language",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/expression-language.git",
-                "reference": "b8ec919a6d3d47fc4e7845c256d164413207bf73"
+                "reference": "463cb95f80c14136175f4e03f7f6199b01c6b8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/expression-language/zipball/b8ec919a6d3d47fc4e7845c256d164413207bf73",
-                "reference": "b8ec919a6d3d47fc4e7845c256d164413207bf73",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/463cb95f80c14136175f4e03f7f6199b01c6b8b4",
+                "reference": "463cb95f80c14136175f4e03f7f6199b01c6b8b4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "symfony/cache": "^6.4|^7.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "type": "library",
@@ -1872,7 +1874,7 @@
             "description": "Provides an engine that can compile and evaluate expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/expression-language/tree/v7.0.7"
+                "source": "https://github.com/symfony/expression-language/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -1888,26 +1890,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "cc168be6fbdcdf3401f50ae863ee3818ed4338f5"
+                "reference": "802e87002f919296c9f606457d9fa327a0b3d6b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/cc168be6fbdcdf3401f50ae863ee3818ed4338f5",
-                "reference": "cc168be6fbdcdf3401f50ae863ee3818ed4338f5",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/802e87002f919296c9f606457d9fa327a0b3d6b2",
+                "reference": "802e87002f919296c9f606457d9fa327a0b3d6b2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
                 "symfony/process": "^6.4|^7.0"
             },
             "type": "library",
@@ -1936,7 +1940,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.0.7"
+                "source": "https://github.com/symfony/filesystem/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -1952,20 +1956,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "4d58f0f4fe95a30d7b538d71197135483560b97c"
+                "reference": "fbb0ba67688b780efbc886c1a0a0948dcf7205d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/4d58f0f4fe95a30d7b538d71197135483560b97c",
-                "reference": "4d58f0f4fe95a30d7b538d71197135483560b97c",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/fbb0ba67688b780efbc886c1a0a0948dcf7205d6",
+                "reference": "fbb0ba67688b780efbc886c1a0a0948dcf7205d6",
                 "shasum": ""
             },
             "require": {
@@ -2000,7 +2004,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.0.7"
+                "source": "https://github.com/symfony/finder/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -2016,20 +2020,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-28T11:44:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "5d9cee370509056b8b7a5009d7112d045d8f0a64"
+                "reference": "79a20497022b8853416e20c836ee150b754c332a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/5d9cee370509056b8b7a5009d7112d045d8f0a64",
-                "reference": "5d9cee370509056b8b7a5009d7112d045d8f0a64",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/79a20497022b8853416e20c836ee150b754c332a",
+                "reference": "79a20497022b8853416e20c836ee150b754c332a",
                 "shasum": ""
             },
             "require": {
@@ -2038,11 +2042,11 @@
                 "php": ">=8.2",
                 "symfony/cache": "^6.4|^7.0",
                 "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/dependency-injection": "^7.1",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/error-handler": "^6.4|^7.0",
                 "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/filesystem": "^6.4|^7.0",
+                "symfony/filesystem": "^7.1",
                 "symfony/finder": "^6.4|^7.0",
                 "symfony/http-foundation": "^6.4|^7.0",
                 "symfony/http-kernel": "^6.4|^7.0",
@@ -2113,6 +2117,7 @@
                 "symfony/string": "^6.4|^7.0",
                 "symfony/translation": "^6.4|^7.0",
                 "symfony/twig-bundle": "^6.4|^7.0",
+                "symfony/type-info": "^7.1",
                 "symfony/uid": "^6.4|^7.0",
                 "symfony/validator": "^6.4|^7.0",
                 "symfony/web-link": "^6.4|^7.0",
@@ -2146,7 +2151,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v7.0.7"
+                "source": "https://github.com/symfony/framework-bundle/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -2162,20 +2167,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-06-04T06:40:14+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "0194e064b8bdc29381462f790bab04e1cac8fdc8"
+                "reference": "74d171d5b6a1d9e4bfee09a41937c17a7536acfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/0194e064b8bdc29381462f790bab04e1cac8fdc8",
-                "reference": "0194e064b8bdc29381462f790bab04e1cac8fdc8",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/74d171d5b6a1d9e4bfee09a41937c17a7536acfa",
+                "reference": "74d171d5b6a1d9e4bfee09a41937c17a7536acfa",
                 "shasum": ""
             },
             "require": {
@@ -2223,7 +2228,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.0.7"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -2239,25 +2244,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "e07bb9bd86e7cd8ba2d3d9c618eec9d1bbe06d25"
+                "reference": "fa8d1c75b5f33b1302afccf81811f93976c6e26f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/e07bb9bd86e7cd8ba2d3d9c618eec9d1bbe06d25",
-                "reference": "e07bb9bd86e7cd8ba2d3d9c618eec9d1bbe06d25",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/fa8d1c75b5f33b1302afccf81811f93976c6e26f",
+                "reference": "fa8d1c75b5f33b1302afccf81811f93976c6e26f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/error-handler": "^6.4|^7.0",
                 "symfony/event-dispatcher": "^6.4|^7.0",
                 "symfony/http-foundation": "^6.4|^7.0",
@@ -2298,9 +2304,9 @@
                 "symfony/finder": "^6.4|^7.0",
                 "symfony/http-client-contracts": "^2.5|^3",
                 "symfony/process": "^6.4|^7.0",
-                "symfony/property-access": "^6.4|^7.0",
+                "symfony/property-access": "^7.1",
                 "symfony/routing": "^6.4|^7.0",
-                "symfony/serializer": "^6.4.4|^7.0.4",
+                "symfony/serializer": "^7.1",
                 "symfony/stopwatch": "^6.4|^7.0",
                 "symfony/translation": "^6.4|^7.0",
                 "symfony/translation-contracts": "^2.5|^3",
@@ -2336,7 +2342,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.0.7"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -2352,20 +2358,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-29T12:20:25+00:00"
+            "time": "2024-06-04T06:52:15+00:00"
         },
         {
             "name": "symfony/lock",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/lock.git",
-                "reference": "9d6546f0223c1f441e2e6517ad3502c226ac0adb"
+                "reference": "1f8c941f1270dee046e09a826bcdd3b2ebada45e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/lock/zipball/9d6546f0223c1f441e2e6517ad3502c226ac0adb",
-                "reference": "9d6546f0223c1f441e2e6517ad3502c226ac0adb",
+                "url": "https://api.github.com/repos/symfony/lock/zipball/1f8c941f1270dee046e09a826bcdd3b2ebada45e",
+                "reference": "1f8c941f1270dee046e09a826bcdd3b2ebada45e",
                 "shasum": ""
             },
             "require": {
@@ -2414,7 +2420,7 @@
                 "semaphore"
             ],
             "support": {
-                "source": "https://github.com/symfony/lock/tree/v7.0.7"
+                "source": "https://github.com/symfony/lock/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -2430,20 +2436,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "23cc173858776ad451e31f053b1c9f47840b2cfa"
+                "reference": "47aa818121ed3950acd2b58d1d37d08a94f9bf55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/23cc173858776ad451e31f053b1c9f47840b2cfa",
-                "reference": "23cc173858776ad451e31f053b1c9f47840b2cfa",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/47aa818121ed3950acd2b58d1d37d08a94f9bf55",
+                "reference": "47aa818121ed3950acd2b58d1d37d08a94f9bf55",
                 "shasum": ""
             },
             "require": {
@@ -2481,7 +2487,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.0.7"
+                "source": "https://github.com/symfony/options-resolver/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -2497,7 +2503,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2975,78 +2981,17 @@
             "time": "2024-01-29T20:11:03+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v7.0.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "3839e56b94dd1dbd13235d27504e66baf23faba0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/3839e56b94dd1dbd13235d27504e66baf23faba0",
-                "reference": "3839e56b94dd1dbd13235d27504e66baf23faba0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v7.0.7"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-04-18T09:29:19+00:00"
-        },
-        {
             "name": "symfony/property-access",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "8661b861480d2807eb2789ff99d034c0c71ab955"
+                "reference": "74e39e6a6276b8e384f34c6ddbc10a6c9a60193a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/8661b861480d2807eb2789ff99d034c0c71ab955",
-                "reference": "8661b861480d2807eb2789ff99d034c0c71ab955",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/74e39e6a6276b8e384f34c6ddbc10a6c9a60193a",
+                "reference": "74e39e6a6276b8e384f34c6ddbc10a6c9a60193a",
                 "shasum": ""
             },
             "require": {
@@ -3093,7 +3038,7 @@
                 "reflection"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-access/tree/v7.0.7"
+                "source": "https://github.com/symfony/property-access/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -3109,25 +3054,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/property-info",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "f0bdb46e19ab308527b324b7ec36161f6880a532"
+                "reference": "0f80f818c6728f15de30a4f89866d68e4912ae84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/f0bdb46e19ab308527b324b7ec36161f6880a532",
-                "reference": "f0bdb46e19ab308527b324b7ec36161f6880a532",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/0f80f818c6728f15de30a4f89866d68e4912ae84",
+                "reference": "0f80f818c6728f15de30a4f89866d68e4912ae84",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
-                "symfony/string": "^6.4|^7.0"
+                "symfony/string": "^6.4|^7.0",
+                "symfony/type-info": "^7.1"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<5.2",
@@ -3176,7 +3122,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v7.0.7"
+                "source": "https://github.com/symfony/property-info/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -3192,20 +3138,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-28T11:44:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "9f82bf7766ccc9c22ab7aeb9bebb98351483fa5b"
+                "reference": "60c31bab5c45af7f13091b87deb708830f3c96c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/9f82bf7766ccc9c22ab7aeb9bebb98351483fa5b",
-                "reference": "9f82bf7766ccc9c22ab7aeb9bebb98351483fa5b",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/60c31bab5c45af7f13091b87deb708830f3c96c0",
+                "reference": "60c31bab5c45af7f13091b87deb708830f3c96c0",
                 "shasum": ""
             },
             "require": {
@@ -3257,7 +3203,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.0.7"
+                "source": "https://github.com/symfony/routing/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -3273,24 +3219,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "08f0c517acf4b12dfc0d3963cd12f7b8023aea31"
+                "reference": "74817ee48e37cce1a1b33c66ffdb750e7e048c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/08f0c517acf4b12dfc0d3963cd12f7b8023aea31",
-                "reference": "08f0c517acf4b12dfc0d3963cd12f7b8023aea31",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/74817ee48e37cce1a1b33c66ffdb750e7e048c3c",
+                "reference": "74817ee48e37cce1a1b33c66ffdb750e7e048c3c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
@@ -3320,6 +3267,7 @@
                 "symfony/property-access": "^6.4|^7.0",
                 "symfony/property-info": "^6.4|^7.0",
                 "symfony/translation-contracts": "^2.5|^3",
+                "symfony/type-info": "^7.1",
                 "symfony/uid": "^6.4|^7.0",
                 "symfony/validator": "^6.4|^7.0",
                 "symfony/var-dumper": "^6.4|^7.0",
@@ -3352,7 +3300,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v7.0.7"
+                "source": "https://github.com/symfony/serializer/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -3368,7 +3316,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-28T11:44:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3455,16 +3403,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "e405b5424dc2528e02e31ba26b83a79fd4eb8f63"
+                "reference": "60bc311c74e0af215101235aa6f471bcbc032df2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/e405b5424dc2528e02e31ba26b83a79fd4eb8f63",
-                "reference": "e405b5424dc2528e02e31ba26b83a79fd4eb8f63",
+                "url": "https://api.github.com/repos/symfony/string/zipball/60bc311c74e0af215101235aa6f471bcbc032df2",
+                "reference": "60bc311c74e0af215101235aa6f471bcbc032df2",
                 "shasum": ""
             },
             "require": {
@@ -3478,6 +3426,7 @@
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
+                "symfony/emoji": "^7.1",
                 "symfony/error-handler": "^6.4|^7.0",
                 "symfony/http-client": "^6.4|^7.0",
                 "symfony/intl": "^6.4|^7.0",
@@ -3521,7 +3470,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.0.7"
+                "source": "https://github.com/symfony/string/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -3537,20 +3486,102 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-06-04T06:40:14+00:00"
         },
         {
-            "name": "symfony/var-dumper",
-            "version": "v7.0.7",
+            "name": "symfony/type-info",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "d1627b66fd87c8b4d90cabe5671c29d575690924"
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "60b28eb733f1453287f1263ed305b96091e0d1dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/d1627b66fd87c8b4d90cabe5671c29d575690924",
-                "reference": "d1627b66fd87c8b4d90cabe5671c29d575690924",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/60b28eb733f1453287f1263ed305b96091e0d1dc",
+                "reference": "60b28eb733f1453287f1263ed305b96091e0d1dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1|^2.0"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.0",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/property-info": "<6.4"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/property-info": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v7.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T14:59:31+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v7.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "deb2c2b506ff6fdbb340e00b34e9901e1605f293"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/deb2c2b506ff6fdbb340e00b34e9901e1605f293",
+                "reference": "deb2c2b506ff6fdbb340e00b34e9901e1605f293",
                 "shasum": ""
             },
             "require": {
@@ -3604,7 +3635,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.0.7"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -3620,20 +3651,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "cdecc0022e40e90340ba1a59a3d5ccf069777078"
+                "reference": "db82c2b73b88734557cfc30e3270d83fa651b712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/cdecc0022e40e90340ba1a59a3d5ccf069777078",
-                "reference": "cdecc0022e40e90340ba1a59a3d5ccf069777078",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/db82c2b73b88734557cfc30e3270d83fa651b712",
+                "reference": "db82c2b73b88734557cfc30e3270d83fa651b712",
                 "shasum": ""
             },
             "require": {
@@ -3680,7 +3711,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.0.7"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -3696,20 +3727,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:29:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.0.7",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "0d3916ae69ea28b59d94b60c4f2b50f4e25adb5c"
+                "reference": "fa34c77015aa6720469db7003567b9f772492bf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0d3916ae69ea28b59d94b60c4f2b50f4e25adb5c",
-                "reference": "0d3916ae69ea28b59d94b60c4f2b50f4e25adb5c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/fa34c77015aa6720469db7003567b9f772492bf2",
+                "reference": "fa34c77015aa6720469db7003567b9f772492bf2",
                 "shasum": ""
             },
             "require": {
@@ -3751,7 +3782,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.0.7"
+                "source": "https://github.com/symfony/yaml/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -3767,7 +3798,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-28T11:44:19+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -3996,16 +4027,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.1.3",
+            "version": "3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "5b16e25a5355f1f3afdfc2f954a0a80aec4826a8"
+                "reference": "04229f163664973f68f38f6f73d917799168ef24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/5b16e25a5355f1f3afdfc2f954a0a80aec4826a8",
-                "reference": "5b16e25a5355f1f3afdfc2f954a0a80aec4826a8",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/04229f163664973f68f38f6f73d917799168ef24",
+                "reference": "04229f163664973f68f38f6f73d917799168ef24",
                 "shasum": ""
             },
             "require": {
@@ -4047,7 +4078,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.3"
+                "source": "https://github.com/composer/pcre/tree/3.1.4"
             },
             "funding": [
                 {
@@ -4063,7 +4094,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-19T10:26:25+00:00"
+            "time": "2024-05-27T13:40:54+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -5449,12 +5480,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "0ec6bad5f4523eda2514e89d5ea48cde6ebe7f99"
+                "reference": "8583ee6fe6fdd08d3dbf9c273fa41704c3a919c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/0ec6bad5f4523eda2514e89d5ea48cde6ebe7f99",
-                "reference": "0ec6bad5f4523eda2514e89d5ea48cde6ebe7f99",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/8583ee6fe6fdd08d3dbf9c273fa41704c3a919c1",
+                "reference": "8583ee6fe6fdd08d3dbf9c273fa41704c3a919c1",
                 "shasum": ""
             },
             "conflict": {
@@ -5462,6 +5493,7 @@
                 "admidio/admidio": "<4.2.13",
                 "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
                 "aheinze/cockpit": "<2.2",
+                "aimeos/aimeos-core": ">=2022.04.1,<2022.10.17|>=2023.04.1,<2023.10.17|>=2024.04.1,<2024.04.7",
                 "aimeos/aimeos-typo3": "<19.10.12|>=20,<20.10.5",
                 "airesvsg/acf-to-rest-api": "<=3.1",
                 "akaunting/akaunting": "<2.1.13",
@@ -5663,6 +5695,7 @@
                 "funadmin/funadmin": "<=3.2|>=3.3.2,<=3.3.3",
                 "gaoming13/wechat-php-sdk": "<=1.10.2",
                 "genix/cms": "<=1.1.11",
+                "getformwork/formwork": "<1.13",
                 "getgrav/grav": "<1.7.46",
                 "getkirby/cms": "<4.1.1",
                 "getkirby/kirby": "<=2.5.12",
@@ -5969,7 +6002,7 @@
                 "silverstripe/admin": "<1.13.19|>=2,<2.1.8",
                 "silverstripe/assets": ">=1,<1.11.1",
                 "silverstripe/cms": "<4.11.3",
-                "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
+                "silverstripe/comments": ">=1.3,<3.1.1",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
                 "silverstripe/framework": "<4.13.39|>=5,<5.1.11",
                 "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.8.2|>=4,<4.3.7|>=5,<5.1.3",
@@ -5995,7 +6028,7 @@
                 "slim/psr7": "<1.4.1|>=1.5,<1.5.1|>=1.6,<1.6.1",
                 "slim/slim": "<2.6",
                 "slub/slub-events": "<3.0.3",
-                "smarty/smarty": "<3.1.48|>=4,<4.3.1",
+                "smarty/smarty": "<4.5.3|>=5,<5.1.1",
                 "snipe/snipe-it": "<=6.2.2",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
@@ -6006,7 +6039,7 @@
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
                 "ssddanbrown/bookstack": "<22.02.3",
-                "statamic/cms": "<4.46",
+                "statamic/cms": "<4.46|>=5.3,<5.6.2",
                 "stormpath/sdk": "<9.9.99",
                 "studio-42/elfinder": "<2.1.62",
                 "subhh/libconnect": "<7.0.8|>=8,<8.1",
@@ -6023,7 +6056,7 @@
                 "sylius/paypal-plugin": ">=1,<1.2.4|>=1.3,<1.3.1",
                 "sylius/resource-bundle": ">=1,<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
                 "sylius/sylius": "<1.9.10|>=1.10,<1.10.11|>=1.11,<1.11.2|>=1.12.0.0-alpha1,<1.12.16|>=1.13.0.0-alpha1,<1.13.1",
-                "symbiote/silverstripe-multivaluefield": ">=3,<3.0.99",
+                "symbiote/silverstripe-multivaluefield": ">=3,<3.1",
                 "symbiote/silverstripe-queuedjobs": ">=3,<3.0.2|>=3.1,<3.1.4|>=4,<4.0.7|>=4.1,<4.1.2|>=4.2,<4.2.4|>=4.3,<4.3.3|>=4.4,<4.4.3|>=4.5,<4.5.1|>=4.6,<4.6.4",
                 "symbiote/silverstripe-seed": "<6.0.3",
                 "symbiote/silverstripe-versionedfiles": "<=2.0.3",
@@ -6153,7 +6186,7 @@
                 "yidashi/yii2cmf": "<=2",
                 "yii2mod/yii2-cms": "<1.9.2",
                 "yiisoft/yii": "<1.1.29",
-                "yiisoft/yii2": "<2.0.38",
+                "yiisoft/yii2": "<2.0.50",
                 "yiisoft/yii2-authclient": "<2.2.15",
                 "yiisoft/yii2-bootstrap": "<2.0.4",
                 "yiisoft/yii2-dev": "<2.0.43",
@@ -6239,7 +6272,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-23T15:04:32+00:00"
+            "time": "2024-06-03T21:04:39+00:00"
         },
         {
             "name": "sanmai/later",
@@ -7365,6 +7398,67 @@
                 }
             ],
             "time": "2024-05-22T21:24:41+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v7.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "febf90124323a093c7ee06fdb30e765ca3c20028"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/febf90124323a093c7ee06fdb30e765ca3c20028",
+                "reference": "febf90124323a093c7ee06fdb30e765ca3c20028",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "thecodingmachine/safe",

--- a/config/graphql.yaml
+++ b/config/graphql.yaml
@@ -7,7 +7,7 @@ overblog_graphql:
     schema:
       query: RootQuery
       mutation: RootMutation
-      types: [ArticleTeaser, MediaTeaser, NewsTeaser, Image]
+      types: [ArticleTeaser, MediaTeaser, NewsTeaser, Image, SymbolicImage]
     mappings:
       types:
         - type: attribute

--- a/config/graphql/decorators/ArticleTeaser.decorator.yaml
+++ b/config/graphql/decorators/ArticleTeaser.decorator.yaml
@@ -24,4 +24,7 @@ ArticleTeaserDecorator:
           variant:
             type: "String!"
             description: The teaser variant is used to decide which image format is to be returned.
+          forceSymbolic:
+            type: "Boolean"
+            description: If true, the API will always try to return a SymbolicImage, if available. Null otherwise.
         description: Teaser asset can be e.g. pictures or videos

--- a/config/graphql/decorators/ArticleTeaser.decorator.yaml
+++ b/config/graphql/decorators/ArticleTeaser.decorator.yaml
@@ -24,7 +24,7 @@ ArticleTeaserDecorator:
           variant:
             type: "String!"
             description: The teaser variant is used to decide which image format is to be returned.
-          forceSymbolic:
-            type: "Boolean"
-            description: If true, the API will always try to return a SymbolicImage, if available. Null otherwise.
         description: Teaser asset can be e.g. pictures or videos
+      symbolicImage:
+        type: "SymbolicImage"
+        description: symbolic image associated with the teaser

--- a/config/graphql/decorators/NewsTeaser.decorator.yaml
+++ b/config/graphql/decorators/NewsTeaser.decorator.yaml
@@ -21,7 +21,7 @@ NewsTeaserDecorator:
           variant:
             type: "String!"
             description: The teaser variant is used to decide which image format is to be returned.
-          forceSymbolic:
-            type: "Boolean"
-            description: If true, the API will always try to return a SymbolicImage, if available. Null otherwise.
         description: Teaser asset can be e.g. pictures or videos
+      symbolicImage:
+        type: "SymbolicImage"
+        description: symbolic image associated with the teaser

--- a/config/graphql/decorators/NewsTeaser.decorator.yaml
+++ b/config/graphql/decorators/NewsTeaser.decorator.yaml
@@ -21,4 +21,7 @@ NewsTeaserDecorator:
           variant:
             type: "String!"
             description: The teaser variant is used to decide which image format is to be returned.
+          forceSymbolic:
+            type: "Boolean"
+            description: If true, the API will always try to return a SymbolicImage, if available. Null otherwise.
         description: Teaser asset can be e.g. pictures or videos

--- a/config/graphql/types/Other.type.yml
+++ b/config/graphql/types/Other.type.yml
@@ -87,6 +87,14 @@ ImageSource:
       height: { type: "Int!" }
       mediaQuery: { type: "String" }
 
+SymbolicImage:
+  type: "object"
+  inherits: [Asset]
+  config:
+    interfaces: [Asset]
+    fields:
+      url: { type: "String" }
+
 IndexerStatus:
   type: "object"
   config:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -60,19 +60,18 @@ services:
         - '@atoolo_graphql_search.resolver.url_rewriter'
         - '@logger'
       tags:
-        - { name: 'atoolo_graphql_search.resolver.asset.regular', priority: 10 }
+        - { name: 'atoolo_graphql_search.resolver.asset', priority: 20 }
 
-    Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageResolver:
+    Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageHierachyResolver:
       arguments:
         - '@atoolo_graphql_search.resolver.url_rewriter'
         - '@atoolo_resource.navigation_hierarchy_loader'
       tags:
-        - { name: 'atoolo_graphql_search.resolver.asset.symbolic', priority: 10 }
+        - { name: 'atoolo_graphql_search.resolver.asset', priority: 10 }
 
     Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain:
       arguments:
-        - !tagged_iterator { tag: 'atoolo_graphql_search.resolver.asset.regular' }
-        - !tagged_iterator { tag: 'atoolo_graphql_search.resolver.asset.symbolic' }
+        - !tagged_iterator { tag: 'atoolo_graphql_search.resolver.asset' }
 
     Atoolo\GraphQL\Search\Resolver\ResourceKickerResolver:
       arguments:
@@ -83,6 +82,7 @@ services:
     Atoolo\GraphQL\Search\Resolver\ArticleTeaserResolver:
         arguments:
           - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
+          - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
           - '@Atoolo\GraphQL\Search\Resolver\ResourceKickerResolver'
           - '@Atoolo\GraphQL\Search\Resolver\ResourceDateResolver'
         tags:
@@ -90,6 +90,7 @@ services:
 
     Atoolo\GraphQL\Search\Resolver\NewsTeaserResolver:
       arguments:
+        - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
         - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
         - '@Atoolo\GraphQL\Search\Resolver\ResourceDateResolver'
       tags:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -62,7 +62,7 @@ services:
       tags:
         - { name: 'atoolo_graphql_search.resolver.asset', priority: 20 }
 
-    Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageHierachyResolver:
+    Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageHierarchyResolver:
       arguments:
         - '@atoolo_graphql_search.resolver.url_rewriter'
         - '@atoolo_resource.navigation_hierarchy_loader'
@@ -82,7 +82,7 @@ services:
     Atoolo\GraphQL\Search\Resolver\ArticleTeaserResolver:
         arguments:
           - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
-          - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
+          - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageHierarchyResolver'
           - '@Atoolo\GraphQL\Search\Resolver\ResourceKickerResolver'
           - '@Atoolo\GraphQL\Search\Resolver\ResourceDateResolver'
         tags:
@@ -91,7 +91,7 @@ services:
     Atoolo\GraphQL\Search\Resolver\NewsTeaserResolver:
       arguments:
         - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
-        - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
+        - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageHierarchyResolver'
         - '@Atoolo\GraphQL\Search\Resolver\ResourceDateResolver'
       tags:
         - { name: 'atoolo_graphql_search.resolver' }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -55,10 +55,24 @@ services:
         tags:
             - { name: 'atoolo_graphql_search.resolver' }
 
-    Atoolo\GraphQL\Search\Resolver\ResourceAssetResolver:
+    Atoolo\GraphQL\Search\Resolver\Asset\ResourceImageResolver:
       arguments:
         - '@atoolo_graphql_search.resolver.url_rewriter'
         - '@logger'
+      tags:
+        - { name: 'atoolo_graphql_search.resolver.asset.regular', priority: 10 }
+
+    Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageResolver:
+      arguments:
+        - '@atoolo_graphql_search.resolver.url_rewriter'
+        - '@atoolo_resource.navigation_hierarchy_loader'
+      tags:
+        - { name: 'atoolo_graphql_search.resolver.asset.symbolic', priority: 10 }
+
+    Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain:
+      arguments:
+        - !tagged_iterator { tag: 'atoolo_graphql_search.resolver.asset.regular' }
+        - !tagged_iterator { tag: 'atoolo_graphql_search.resolver.asset.symbolic' }
 
     Atoolo\GraphQL\Search\Resolver\ResourceKickerResolver:
       arguments:
@@ -68,7 +82,7 @@ services:
 
     Atoolo\GraphQL\Search\Resolver\ArticleTeaserResolver:
         arguments:
-          - '@Atoolo\GraphQL\Search\Resolver\ResourceAssetResolver'
+          - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
           - '@Atoolo\GraphQL\Search\Resolver\ResourceKickerResolver'
           - '@Atoolo\GraphQL\Search\Resolver\ResourceDateResolver'
         tags:
@@ -76,7 +90,7 @@ services:
 
     Atoolo\GraphQL\Search\Resolver\NewsTeaserResolver:
       arguments:
-        - '@Atoolo\GraphQL\Search\Resolver\ResourceAssetResolver'
+        - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
         - '@Atoolo\GraphQL\Search\Resolver\ResourceDateResolver'
       tags:
         - { name: 'atoolo_graphql_search.resolver' }

--- a/src/Resolver/ArticleTeaserResolver.php
+++ b/src/Resolver/ArticleTeaserResolver.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Atoolo\GraphQL\Search\Resolver;
 
-use Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain;
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolver;
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageResolver;
 use Atoolo\GraphQL\Search\Types\ArticleTeaser;
 use Atoolo\GraphQL\Search\Types\Asset;
 use DateTime;
@@ -31,7 +32,8 @@ use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 class ArticleTeaserResolver implements Resolver
 {
     public function __construct(
-        private readonly ResourceAssetResolverChain $assetResolver,
+        private readonly ResourceAssetResolver $assetResolver,
+        private readonly ResourceSymbolicImageResolver $symbolicImageResolver,
         private readonly ResourceKickerResolver $kickerResolver,
         private readonly ResourceDateResolver $dateResolver
     ) {
@@ -54,5 +56,12 @@ class ArticleTeaserResolver implements Resolver
         ArgumentInterface $args
     ): ?Asset {
         return $this->assetResolver->getAsset($teaser->resource, $args);
+    }
+
+    public function getSymbolicImage(
+        ArticleTeaser $teaser,
+        ArgumentInterface $args
+    ): ?Asset {
+        return $this->symbolicImageResolver->getSymbolicImage($teaser->resource, $args);
     }
 }

--- a/src/Resolver/ArticleTeaserResolver.php
+++ b/src/Resolver/ArticleTeaserResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\GraphQL\Search\Resolver;
 
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain;
 use Atoolo\GraphQL\Search\Types\ArticleTeaser;
 use Atoolo\GraphQL\Search\Types\Asset;
 use DateTime;
@@ -30,7 +31,7 @@ use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 class ArticleTeaserResolver implements Resolver
 {
     public function __construct(
-        private readonly ResourceAssetResolver $assetResolver,
+        private readonly ResourceAssetResolverChain $assetResolver,
         private readonly ResourceKickerResolver $kickerResolver,
         private readonly ResourceDateResolver $dateResolver
     ) {

--- a/src/Resolver/ArticleTeaserResolver.php
+++ b/src/Resolver/ArticleTeaserResolver.php
@@ -62,6 +62,7 @@ class ArticleTeaserResolver implements Resolver
         ArticleTeaser $teaser,
         ArgumentInterface $args
     ): ?Asset {
-        return $this->symbolicImageResolver->getSymbolicImage($teaser->resource, $args);
+        return $this->symbolicImageResolver
+            ->getSymbolicImage($teaser->resource, $args);
     }
 }

--- a/src/Resolver/Asset/ResourceAssetResolver.php
+++ b/src/Resolver/Asset/ResourceAssetResolver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Resolver\Asset;
+
+use Atoolo\GraphQL\Search\Resolver\Resolver;
+use Atoolo\GraphQL\Search\Types\Asset;
+use Atoolo\Resource\Resource;
+use Overblog\GraphQLBundle\Definition\ArgumentInterface;
+
+interface ResourceAssetResolver extends Resolver
+{
+    public function getAsset(
+        Resource $resource,
+        ArgumentInterface $args
+    ): ?Asset;
+}

--- a/src/Resolver/Asset/ResourceAssetResolverChain.php
+++ b/src/Resolver/Asset/ResourceAssetResolverChain.php
@@ -12,31 +12,13 @@ use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 class ResourceAssetResolverChain implements Resolver
 {
     /**
-     * @var array<string, ResourceAssetResolver>
-     */
-    private readonly array $regularAssetResolvers;
-
-    /**
-     * @var array<string, ResourceAssetResolver>
-     */
-    private readonly array $symbolicAssetResolvers;
-
-    /**
-     * @param array<string, ResourceAssetResolver> $regularAssetResolvers
-     * @param array<string, ResourceAssetResolver> $symbolicAssetResolvers
+     * @param array<ResourceAssetResolver> $regularAssetResolvers
+     * @param array<ResourceAssetResolver> $symbolicAssetResolvers
      */
     public function __construct(
-        iterable $regularAssetResolvers,
-        iterable $symbolicAssetResolvers
+        private readonly iterable $regularAssetResolvers,
+        private readonly iterable $symbolicAssetResolvers
     ) {
-        $this->regularAssetResolvers =
-            $regularAssetResolvers instanceof \Traversable ?
-            iterator_to_array($regularAssetResolvers) :
-            $regularAssetResolvers;
-        $this->symbolicAssetResolvers =
-            $symbolicAssetResolvers instanceof \Traversable ?
-            iterator_to_array($symbolicAssetResolvers) :
-            $symbolicAssetResolvers;
     }
 
     /**

--- a/src/Resolver/Asset/ResourceAssetResolverChain.php
+++ b/src/Resolver/Asset/ResourceAssetResolverChain.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Resolver\Asset;
 
 use Atoolo\GraphQL\Search\Types\Asset;
-use Atoolo\GraphQL\Search\Types\SymbolicImage;
 use Atoolo\Resource\Resource;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 
-class ResourceAssetResolverChain implements ResourceAssetResolver, ResourceSymbolicImageResolver
+class ResourceAssetResolverChain implements ResourceAssetResolver
 {
     /**
      * @param array<ResourceAssetResolver> $resolvers
@@ -30,25 +29,6 @@ class ResourceAssetResolverChain implements ResourceAssetResolver, ResourceSymbo
             );
             if ($asset !== null) {
                 return $asset;
-            }
-        }
-        return null;
-    }
-
-    public function getSymbolicImage(
-        Resource $resource,
-        ArgumentInterface $args
-    ): ?SymbolicImage {
-        foreach ($this->resolvers as $resolver) {
-            if (!$resolver instanceof ResourceSymbolicImageResolver) {
-                continue;
-            }
-            $symbolicImage = $resolver->getSymbolicImage(
-                $resource,
-                $args
-            );
-            if ($symbolicImage !== null) {
-                return $symbolicImage;
             }
         }
         return null;

--- a/src/Resolver/Asset/ResourceAssetResolverChain.php
+++ b/src/Resolver/Asset/ResourceAssetResolverChain.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Resolver\Asset;
+
+use Atoolo\GraphQL\Search\Resolver\Resolver;
+use Atoolo\GraphQL\Search\Types\Asset;
+use Atoolo\Resource\Resource;
+use Overblog\GraphQLBundle\Definition\ArgumentInterface;
+
+class ResourceAssetResolverChain implements Resolver
+{
+    /**
+     * @var array<string, ResourceAssetResolver>
+     */
+    private readonly array $regularAssetResolvers;
+
+    /**
+     * @var array<string, ResourceAssetResolver>
+     */
+    private readonly array $symbolicAssetResolvers;
+
+    /**
+     * @param array<string, ResourceAssetResolver> $regularAssetResolvers
+     * @param array<string, ResourceAssetResolver> $symbolicAssetResolvers
+     */
+    public function __construct(
+        iterable $regularAssetResolvers,
+        iterable $symbolicAssetResolvers
+    ) {
+        $this->regularAssetResolvers =
+            $regularAssetResolvers instanceof \Traversable ?
+            iterator_to_array($regularAssetResolvers) :
+            $regularAssetResolvers;
+        $this->symbolicAssetResolvers =
+            $symbolicAssetResolvers instanceof \Traversable ?
+            iterator_to_array($symbolicAssetResolvers) :
+            $symbolicAssetResolvers;
+    }
+
+    /**
+     * Iterates over all regular asset resolvers (tagged with
+     * `atoolo_graphql_search.resolver.asset.regular`) and all
+     * symbolic asset resolvers (tagged with
+     * `atoolo_graphql_search.resolver.asset.symbolic`) and returns
+     * the first resolved asset that is not null. All  regular asset
+     * resolvers will always have priority over all symbolic asset resolvers.
+     * Passing the argument `forceSymbolic` will cause this method to
+     * only apply symbolic asset resolvers, ignoring the regular assert
+     * resolvers.
+     */
+    public function getAsset(
+        Resource $resource,
+        ArgumentInterface $args
+    ): ?Asset {
+        if ($args['forceSymbolic'] ?? false) {
+            return $this->getAssetSymbolic($resource, $args);
+        }
+        return $this->getAssetRegular($resource, $args)
+            ?? $this->getAssetSymbolic($resource, $args);
+    }
+
+    public function getAssetRegular(
+        Resource $resource,
+        ArgumentInterface $args
+    ): ?Asset {
+        foreach ($this->regularAssetResolvers as $regularAssetResolver) {
+            $asset = $regularAssetResolver->getAsset(
+                $resource,
+                $args
+            );
+            if ($asset !== null) {
+                return $asset;
+            }
+        }
+        return null;
+    }
+
+    public function getAssetSymbolic(
+        Resource $resource,
+        ArgumentInterface $args
+    ): ?Asset {
+        foreach ($this->symbolicAssetResolvers as $symbolicAssetResolvers) {
+            $asset = $symbolicAssetResolvers->getAsset(
+                $resource,
+                $args
+            );
+            if ($asset !== null) {
+                return $asset;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Resolver/Asset/ResourceImageResolver.php
+++ b/src/Resolver/Asset/ResourceImageResolver.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Atoolo\GraphQL\Search\Resolver;
+namespace Atoolo\GraphQL\Search\Resolver\Asset;
 
+use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
+use Atoolo\GraphQL\Search\Resolver\UrlRewriterType;
 use Atoolo\GraphQL\Search\Types\Asset;
 use Atoolo\GraphQL\Search\Types\Image;
 use Atoolo\GraphQL\Search\Types\ImageCharacteristic;
@@ -31,7 +33,7 @@ use Psr\Log\LoggerInterface;
  *     mediaQuery?: string
  * }
  */
-class ResourceAssetResolver
+class ResourceImageResolver implements ResourceAssetResolver
 {
     public function __construct(
         private readonly UrlRewriter $urlRewriter,
@@ -43,6 +45,13 @@ class ResourceAssetResolver
         Resource $resource,
         ArgumentInterface $args
     ): ?Asset {
+        return $this->getImage($resource, $args);
+    }
+
+    public function getImage(
+        Resource $resource,
+        ArgumentInterface $args
+    ): ?Image {
 
         /** @var ImageData|array{} $imageData */
         $imageData = $resource->data->getAssociativeArray(

--- a/src/Resolver/Asset/ResourceSymbolicImageHierachyResolver.php
+++ b/src/Resolver/Asset/ResourceSymbolicImageHierachyResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Resolver\Asset;
+
+use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
+use Atoolo\GraphQL\Search\Resolver\UrlRewriterType;
+use Atoolo\GraphQL\Search\Types\Asset;
+use Atoolo\GraphQL\Search\Types\SymbolicImage;
+use Atoolo\Resource\Resource;
+use Atoolo\Resource\ResourceHierarchyLoader;
+use Atoolo\Resource\ResourceHierarchyWalker;
+use Overblog\GraphQLBundle\Definition\ArgumentInterface;
+
+class ResourceSymbolicImageHierachyResolver implements ResourceAssetResolver, ResourceSymbolicImageResolver
+{
+    public function __construct(
+        private readonly UrlRewriter $urlRewriter,
+        private readonly ResourceHierarchyLoader $hierarchyLoader
+    ) {
+    }
+
+    public function getAsset(
+        Resource $resource,
+        ArgumentInterface $args
+    ): ?Asset {
+        return $this->getSymbolicImage($resource, $args);
+    }
+
+    /**
+     * Traverses the resources hierarchy from bottom
+     * to top (including the passed resource) and returns
+     * the first non-null symbolic image found in the
+     * base data
+     */
+    public function getSymbolicImage(
+        Resource $resource,
+        ArgumentInterface $args
+    ): ?SymbolicImage {
+        $walker = new ResourceHierarchyWalker($this->hierarchyLoader);
+        $walker->init($resource);
+        $currentResource = $resource;
+        do {
+            $url = $currentResource->data->getString('base.symbolicImage.url');
+            if (!empty($url)) {
+                $rewrittenUrl = $this->urlRewriter->rewrite(
+                    UrlRewriterType::IMAGE,
+                    $url
+                );
+                return  new SymbolicImage($rewrittenUrl);
+            }
+        } while ($currentResource = $walker->primaryParent());
+        return null;
+    }
+}

--- a/src/Resolver/Asset/ResourceSymbolicImageHierarchyResolver.php
+++ b/src/Resolver/Asset/ResourceSymbolicImageHierarchyResolver.php
@@ -13,7 +13,9 @@ use Atoolo\Resource\ResourceHierarchyLoader;
 use Atoolo\Resource\ResourceHierarchyWalker;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 
-class ResourceSymbolicImageHierarchyResolver implements ResourceAssetResolver, ResourceSymbolicImageResolver
+class ResourceSymbolicImageHierarchyResolver implements
+    ResourceAssetResolver,
+    ResourceSymbolicImageResolver
 {
     public function __construct(
         private readonly UrlRewriter $urlRewriter,

--- a/src/Resolver/Asset/ResourceSymbolicImageHierarchyResolver.php
+++ b/src/Resolver/Asset/ResourceSymbolicImageHierarchyResolver.php
@@ -13,7 +13,7 @@ use Atoolo\Resource\ResourceHierarchyLoader;
 use Atoolo\Resource\ResourceHierarchyWalker;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 
-class ResourceSymbolicImageHierachyResolver implements ResourceAssetResolver, ResourceSymbolicImageResolver
+class ResourceSymbolicImageHierarchyResolver implements ResourceAssetResolver, ResourceSymbolicImageResolver
 {
     public function __construct(
         private readonly UrlRewriter $urlRewriter,

--- a/src/Resolver/Asset/ResourceSymbolicImageResolver.php
+++ b/src/Resolver/Asset/ResourceSymbolicImageResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Resolver\Asset;
+
+use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
+use Atoolo\GraphQL\Search\Resolver\UrlRewriterType;
+use Atoolo\GraphQL\Search\Types\Asset;
+use Atoolo\GraphQL\Search\Types\SymbolicImage;
+use Atoolo\Resource\Resource;
+use Atoolo\Resource\ResourceHierarchyLoader;
+use Atoolo\Resource\ResourceHierarchyWalker;
+use Overblog\GraphQLBundle\Definition\ArgumentInterface;
+
+class ResourceSymbolicImageResolver implements ResourceAssetResolver
+{
+    public function __construct(
+        private readonly UrlRewriter $urlRewriter,
+        private readonly ResourceHierarchyLoader $hierarchyLoader
+    ) {
+    }
+
+    public function getAsset(
+        Resource $resource,
+        ArgumentInterface $args
+    ): ?Asset {
+        return $this->getSymbolicImage($resource, $args);
+    }
+
+    /**
+     * Traverses the resources hierarchy from bottom
+     * to top (including the passed resource) and returns
+     * the first non-null symbolic image found in the
+     * base data
+     */
+    public function getSymbolicImage(
+        Resource $resource,
+        ArgumentInterface $args
+    ): ?SymbolicImage {
+        $walker = new ResourceHierarchyWalker($this->hierarchyLoader);
+        $walker->init($resource);
+        $currentResource = $resource;
+        do {
+            $url = $currentResource->data->getString('base.symbolicImage.url');
+            if (!empty($url)) {
+                $rewrittenUrl = $this->urlRewriter->rewrite(
+                    UrlRewriterType::IMAGE,
+                    $url
+                );
+                return  new SymbolicImage($rewrittenUrl);
+            }
+        } while ($currentResource = $walker->primaryParent());
+        return null;
+    }
+}

--- a/src/Resolver/Asset/ResourceSymbolicImageResolver.php
+++ b/src/Resolver/Asset/ResourceSymbolicImageResolver.php
@@ -4,53 +4,15 @@ declare(strict_types=1);
 
 namespace Atoolo\GraphQL\Search\Resolver\Asset;
 
-use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
-use Atoolo\GraphQL\Search\Resolver\UrlRewriterType;
-use Atoolo\GraphQL\Search\Types\Asset;
+use Atoolo\GraphQL\Search\Resolver\Resolver;
 use Atoolo\GraphQL\Search\Types\SymbolicImage;
 use Atoolo\Resource\Resource;
-use Atoolo\Resource\ResourceHierarchyLoader;
-use Atoolo\Resource\ResourceHierarchyWalker;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 
-class ResourceSymbolicImageResolver implements ResourceAssetResolver
+interface ResourceSymbolicImageResolver extends Resolver
 {
-    public function __construct(
-        private readonly UrlRewriter $urlRewriter,
-        private readonly ResourceHierarchyLoader $hierarchyLoader
-    ) {
-    }
-
-    public function getAsset(
-        Resource $resource,
-        ArgumentInterface $args
-    ): ?Asset {
-        return $this->getSymbolicImage($resource, $args);
-    }
-
-    /**
-     * Traverses the resources hierarchy from bottom
-     * to top (including the passed resource) and returns
-     * the first non-null symbolic image found in the
-     * base data
-     */
     public function getSymbolicImage(
         Resource $resource,
         ArgumentInterface $args
-    ): ?SymbolicImage {
-        $walker = new ResourceHierarchyWalker($this->hierarchyLoader);
-        $walker->init($resource);
-        $currentResource = $resource;
-        do {
-            $url = $currentResource->data->getString('base.symbolicImage.url');
-            if (!empty($url)) {
-                $rewrittenUrl = $this->urlRewriter->rewrite(
-                    UrlRewriterType::IMAGE,
-                    $url
-                );
-                return  new SymbolicImage($rewrittenUrl);
-            }
-        } while ($currentResource = $walker->primaryParent());
-        return null;
-    }
+    ): ?SymbolicImage;
 }

--- a/src/Resolver/NewsTeaserResolver.php
+++ b/src/Resolver/NewsTeaserResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\GraphQL\Search\Resolver;
 
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain;
 use Atoolo\GraphQL\Search\Types\Asset;
 use Atoolo\GraphQL\Search\Types\NewsTeaser;
 use DateTime;
@@ -12,7 +13,7 @@ use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 class NewsTeaserResolver implements Resolver
 {
     public function __construct(
-        private readonly ResourceAssetResolver $assetResolver,
+        private readonly ResourceAssetResolverChain $assetResolver,
         private readonly ResourceDateResolver $dateResolver
     ) {
     }

--- a/src/Resolver/NewsTeaserResolver.php
+++ b/src/Resolver/NewsTeaserResolver.php
@@ -38,6 +38,7 @@ class NewsTeaserResolver implements Resolver
         NewsTeaser $teaser,
         ArgumentInterface $args
     ): ?SymbolicImage {
-        return $this->symbolicImageResolver->getSymbolicImage($teaser->resource, $args);
+        return $this->symbolicImageResolver
+            ->getSymbolicImage($teaser->resource, $args);
     }
 }

--- a/src/Resolver/NewsTeaserResolver.php
+++ b/src/Resolver/NewsTeaserResolver.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace Atoolo\GraphQL\Search\Resolver;
 
-use Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain;
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolver;
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageResolver;
 use Atoolo\GraphQL\Search\Types\Asset;
 use Atoolo\GraphQL\Search\Types\NewsTeaser;
+use Atoolo\GraphQL\Search\Types\SymbolicImage;
 use DateTime;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 
 class NewsTeaserResolver implements Resolver
 {
     public function __construct(
-        private readonly ResourceAssetResolverChain $assetResolver,
+        private readonly ResourceAssetResolver $assetResolver,
+        private readonly ResourceSymbolicImageResolver $symbolicImageResolver,
         private readonly ResourceDateResolver $dateResolver
     ) {
     }
@@ -29,5 +32,12 @@ class NewsTeaserResolver implements Resolver
         ArgumentInterface $args
     ): ?Asset {
         return $this->assetResolver->getAsset($teaser->resource, $args);
+    }
+
+    public function getSymbolicImage(
+        NewsTeaser $teaser,
+        ArgumentInterface $args
+    ): ?SymbolicImage {
+        return $this->symbolicImageResolver->getSymbolicImage($teaser->resource, $args);
     }
 }

--- a/src/Types/SymbolicImage.php
+++ b/src/Types/SymbolicImage.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Types;
+
+/**
+ * @codeCoverageIgnore
+ */
+class SymbolicImage extends Asset
+{
+    public function __construct(
+        public readonly string $url
+    ) {
+        parent::__construct(null, null, null);
+    }
+}

--- a/test/Resolver/ArticleTeaserResolverTest.php
+++ b/test/Resolver/ArticleTeaserResolverTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Test\Resolver;
 
 use Atoolo\GraphQL\Search\Resolver\ArticleTeaserResolver;
-use Atoolo\GraphQL\Search\Resolver\ResourceAssetResolver;
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolver;
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageResolver;
 use Atoolo\GraphQL\Search\Resolver\ResourceDateResolver;
 use Atoolo\GraphQL\Search\Resolver\ResourceKickerResolver;
 use Atoolo\GraphQL\Search\Types\ArticleTeaser;
@@ -23,6 +24,8 @@ class ArticleTeaserResolverTest extends TestCase
 
     private ResourceAssetResolver&MockObject $assetResolver;
 
+    private ResourceSymbolicImageResolver&MockObject $symbolicImageResolver;
+
     private ResourceKickerResolver&MockObject $kickerResolver;
 
     private ResourceDateResolver&MockObject $dateResolver;
@@ -35,6 +38,9 @@ class ArticleTeaserResolverTest extends TestCase
         $this->assetResolver = $this->createMock(
             ResourceAssetResolver::class
         );
+        $this->symbolicImageResolver = $this->createMock(
+            ResourceSymbolicImageResolver::class
+        );
         $this->kickerResolver = $this->createMock(
             ResourceKickerResolver::class
         );
@@ -43,6 +49,7 @@ class ArticleTeaserResolverTest extends TestCase
         );
         $this->resolver = new ArticleTeaserResolver(
             $this->assetResolver,
+            $this->symbolicImageResolver,
             $this->kickerResolver,
             $this->dateResolver
         );
@@ -75,6 +82,21 @@ class ArticleTeaserResolverTest extends TestCase
         $args = $this->createStub(ArgumentInterface::class);
 
         $this->resolver->getAsset($teaser, $args);
+    }
+
+    public function testGetSymbolicImage(): void
+    {
+        $this->symbolicImageResolver->expects($this->once())
+            ->method('getSymbolicImage');
+        $teaser = new ArticleTeaser(
+            '',
+            '',
+            '',
+            $this->createStub(Resource::class)
+        );
+        $args = $this->createStub(ArgumentInterface::class);
+
+        $this->resolver->getSymbolicImage($teaser, $args);
     }
 
     public function testGetKicker(): void

--- a/test/Resolver/Asset/ResourceAssetResolverChainTest.php
+++ b/test/Resolver/Asset/ResourceAssetResolverChainTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Test\Resolver;
+
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolver;
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain;
+use Atoolo\GraphQL\Search\Test\TestResourceFactory;
+use Atoolo\GraphQL\Search\Types\Image;
+use Atoolo\Resource\Resource;
+use Overblog\GraphQLBundle\Definition\ArgumentInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResourceAssetResolverChain::class)]
+class ResourceAssetResolverChainTest extends TestCase
+{
+    private ResourceAssetResolverChain $resolver;
+
+    private ResourceAssetResolver&MockObject $firstInnerResolver;
+
+    private ResourceAssetResolver&MockObject $lastInnerResolver;
+
+    public function setUp(): void
+    {
+        $this->firstInnerResolver = $this->createMock(
+            ResourceAssetResolver::class
+        );
+        $this->lastInnerResolver = $this->createMock(
+            ResourceAssetResolver::class
+        );
+        $this->resolver = new ResourceAssetResolverChain([
+            $this->firstInnerResolver,
+            $this->lastInnerResolver
+        ]);
+    }
+
+    public function testGetAssetWithoutResult(): void
+    {
+        $resource = $this->createResource([]);
+        $args = $this->createStub(ArgumentInterface::class);
+        $this->firstInnerResolver
+            ->expects($this->once())
+            ->method('getAsset');
+        $this->lastInnerResolver
+            ->expects($this->once())
+            ->method('getAsset');
+        $asset = $this->resolver->getAsset($resource, $args);
+        $this->assertNull(
+            $asset,
+            'asset should be null'
+        );
+    }
+
+    public function testGetAssetWithResultInFirst(): void
+    {
+        $resource = $this->createResource([]);
+        $args = $this->createStub(ArgumentInterface::class);
+        $expected = new Image(null, null, null, null, null, null, []);
+        $this->firstInnerResolver
+            ->expects($this->once())
+            ->method('getAsset')
+            ->willReturn($expected);
+        $this->lastInnerResolver
+            ->expects($this->never())
+            ->method('getAsset');
+        $asset = $this->resolver->getAsset($resource, $args);
+        $this->assertEquals(
+            $expected,
+            $asset
+        );
+    }
+
+    public function testGetAssetWithResultInLast(): void
+    {
+        $resource = $this->createResource([]);
+        $args = $this->createStub(ArgumentInterface::class);
+        $expected = new Image(null, null, null, null, null, null, []);
+        $this->firstInnerResolver
+            ->expects($this->once())
+            ->method('getAsset');
+        $this->lastInnerResolver
+            ->expects($this->once())
+            ->method('getAsset')
+            ->willReturn($expected);
+        $asset = $this->resolver->getAsset($resource, $args);
+        $this->assertEquals(
+            $expected,
+            $asset
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    private function createResource(array $data): Resource
+    {
+        return TestResourceFactory::create($data);
+    }
+}

--- a/test/Resolver/Asset/ResourceImageResolverTest.php
+++ b/test/Resolver/Asset/ResourceImageResolverTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\GraphQL\Search\Test\Resolver;
 
-use Atoolo\GraphQL\Search\Resolver\ResourceAssetResolver;
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceImageResolver;
 use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
 use Atoolo\GraphQL\Search\Test\TestResourceFactory;
 use Atoolo\GraphQL\Search\Types\Image;
@@ -19,10 +19,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-#[CoversClass(ResourceAssetResolver::class)]
-class ResourceAssetResolverTest extends TestCase
+#[CoversClass(ResourceImageResolver::class)]
+class ResourceImageResolverTest extends TestCase
 {
-    private ResourceAssetResolver $resolver;
+    private ResourceImageResolver $resolver;
 
     private UrlRewriter&MockObject $urlRewriter;
 
@@ -40,7 +40,7 @@ class ResourceAssetResolverTest extends TestCase
             LoggerInterface::class
         );
 
-        $this->resolver = new ResourceAssetResolver(
+        $this->resolver = new ResourceImageResolver(
             $this->urlRewriter,
             $this->logger
         );

--- a/test/Resolver/Asset/ResourceSymbolicImageHierarchyResolverTest.php
+++ b/test/Resolver/Asset/ResourceSymbolicImageHierarchyResolverTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Test\Resolver;
+
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageHierarchyResolver;
+use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
+use Atoolo\GraphQL\Search\Resolver\UrlRewriterType;
+use Atoolo\GraphQL\Search\Test\TestResourceFactory;
+use Atoolo\GraphQL\Search\Types\Image;
+use Atoolo\GraphQL\Search\Types\ImageCharacteristic;
+use Atoolo\GraphQL\Search\Types\ImageSource;
+use Atoolo\GraphQL\Search\Types\SymbolicImage;
+use Atoolo\Resource\Resource;
+use Atoolo\Resource\ResourceHierarchyLoader;
+use Atoolo\Resource\ResourceLocation;
+use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Definition\ArgumentInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+#[CoversClass(ResourceSymbolicImageHierarchyResolver::class)]
+class ResourceSymbolicImageHierarchyResolverTest extends TestCase
+{
+    private ResourceSymbolicImageHierarchyResolver $resolver;
+
+    private UrlRewriter&MockObject $urlRewriter;
+
+    private ResourceHierarchyLoader&MockObject $hierarchyLoader;
+
+    /**
+     * @throws Exception
+     */
+    public function setUp(): void
+    {
+        $this->urlRewriter = $this->createMock(
+            UrlRewriter::class
+        );
+        $this->hierarchyLoader = $this->createMock(
+            ResourceHierarchyLoader::class
+        );
+        $this->resolver = new ResourceSymbolicImageHierarchyResolver(
+            $this->urlRewriter,
+            $this->hierarchyLoader
+        );
+    }
+
+    public function testGetAssetWithoutResult(): void
+    {
+        $resource = $this->createResource([]);
+        $args = $this->createStub(ArgumentInterface::class);
+        $symbolicImage = $this->resolver->getAsset($resource, $args);
+        $this->assertNull(
+            $symbolicImage,
+            'symbolicImage should be null'
+        );
+    }
+
+    public function testGetAssetWithResult(): void
+    {
+        $symbolicImageUrl = '/some_url.svg';
+        $parentResource = $this->createResource([
+            'base' => [
+                'symbolicImage' => [
+                    'url' => $symbolicImageUrl
+                ]
+            ]
+        ]);
+        $parentResourceLocation = $parentResource->toLocation();
+        $childResource = $this->createResource([]);
+        $args = $this->createStub(ArgumentInterface::class);
+        $this->hierarchyLoader
+            ->expects($this->atLeastOnce())
+            ->method('getPrimaryParentLocation')
+            ->with($childResource)
+            ->willReturn($parentResourceLocation);
+        $this->hierarchyLoader
+            ->expects($this->atLeastOnce())
+            ->method('load')
+            ->with($parentResourceLocation)
+            ->willReturn($parentResource);
+        $this->urlRewriter
+            ->expects($this->once())
+            ->method('rewrite')
+            ->with(
+                UrlRewriterType::IMAGE,
+                $symbolicImageUrl
+            )->willReturn(
+                $symbolicImageUrl
+            );
+        /** @var SymbolicImage $symbolicImage */
+        $symbolicImage = $this->resolver->getAsset($childResource, $args);
+        $this->assertEquals(
+            $symbolicImage->url,
+            $symbolicImageUrl
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    private function createResource(array $data): Resource
+    {
+        return TestResourceFactory::create($data);
+    }
+}

--- a/test/Resolver/NewsTeaserResolverTest.php
+++ b/test/Resolver/NewsTeaserResolverTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Test\Resolver;
 
 use Atoolo\GraphQL\Search\Resolver\NewsTeaserResolver;
-use Atoolo\GraphQL\Search\Resolver\ResourceAssetResolver;
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolver;
+use Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageResolver;
 use Atoolo\GraphQL\Search\Resolver\ResourceDateResolver;
 use Atoolo\GraphQL\Search\Types\NewsTeaser;
 use Atoolo\Resource\Resource;
@@ -21,6 +22,8 @@ class NewsTeaserResolverTest extends TestCase
 
     private ResourceAssetResolver&MockObject $assetResolver;
 
+    private ResourceSymbolicImageResolver&MockObject $symbolicImageResolver;
+
     private ResourceDateResolver&MockObject $dateResolver;
 
     public function setUp(): void
@@ -28,11 +31,15 @@ class NewsTeaserResolverTest extends TestCase
         $this->assetResolver = $this->createMock(
             ResourceAssetResolver::class
         );
+        $this->symbolicImageResolver = $this->createMock(
+            ResourceSymbolicImageResolver::class
+        );
         $this->dateResolver = $this->createMock(
             ResourceDateResolver::class
         );
         $this->newsTeaserResolver = new NewsTeaserResolver(
             $this->assetResolver,
+            $this->symbolicImageResolver,
             $this->dateResolver
         );
     }
@@ -64,5 +71,20 @@ class NewsTeaserResolverTest extends TestCase
         $args = $this->createStub(ArgumentInterface::class);
 
         $this->newsTeaserResolver->getAsset($teaser, $args);
+    }
+
+    public function testGetSymbolicImage(): void
+    {
+        $this->symbolicImageResolver->expects($this->once())
+            ->method('getSymbolicImage');
+        $teaser = new NewsTeaser(
+            '',
+            '',
+            '',
+            $this->createStub(Resource::class)
+        );
+        $args = $this->createStub(ArgumentInterface::class);
+
+        $this->newsTeaserResolver->getSymbolicImage($teaser, $args);
     }
 }


### PR DESCRIPTION
- Adds a new graphql type `SymbolicImage` that inherits from `Asset`. `SymbolicImage`s currently only have an `url`.
- ~Adds a new parameter called `forceSymbolic` for the `asset` field in teasers. This way users can force the api to return what we define as a "symbolic" asset~.
- Moved and renamed `Atoolo\GraphQL\Search\Resolver\ResourceAssetResolver` to `Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain` and added several resolvers.

~The `ResourceAssetResolverChain` can now be considered the "main" resolver for assets. It iterates over all `ResourceAssetResolver`s that are tagged with either `atoolo_graphql_search.resolver.asset.regular` or `atoolo_graphql_search.resolver.asset.symbolic` and returns the first non-null result. That way, it can differentiate between "regular" and "symbolic" resolvers. All regular resolvers will always have priority over all symbolic resolvers (unless `froceSymbolic` is set to true, in which case only symbolic resolvers will be executed).~


I skipped tests for now and will add them later.