### PR TITLE
feat: set id for symbolic image resolver service

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -62,7 +62,8 @@ services:
       tags:
         - { name: 'atoolo_graphql_search.resolver.asset', priority: 20 }
 
-    Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageHierarchyResolver:
+    atoolo_graphql_search.resolver.asset.resource_symbolic_image_resolver:
+      class: Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageHierarchyResolver
       arguments:
         - '@atoolo_graphql_search.resolver.url_rewriter'
         - '@atoolo_resource.navigation_hierarchy_loader'
@@ -82,7 +83,7 @@ services:
     Atoolo\GraphQL\Search\Resolver\ArticleTeaserResolver:
         arguments:
           - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
-          - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageHierarchyResolver'
+          - '@atoolo_graphql_search.resolver.asset.resource_symbolic_image_resolver'
           - '@Atoolo\GraphQL\Search\Resolver\ResourceKickerResolver'
           - '@Atoolo\GraphQL\Search\Resolver\ResourceDateResolver'
         tags:
@@ -91,7 +92,7 @@ services:
     Atoolo\GraphQL\Search\Resolver\NewsTeaserResolver:
       arguments:
         - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
-        - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageHierarchyResolver'
+        - '@atoolo_graphql_search.resolver.asset.resource_symbolic_image_resolver'
         - '@Atoolo\GraphQL\Search\Resolver\ResourceDateResolver'
       tags:
         - { name: 'atoolo_graphql_search.resolver' }


### PR DESCRIPTION
Sets an id of the default symbolic image resolver to `atoolo_graphql_search.resolver.asset.resource_symbolic_image_resolver`. 

This service can be expected to be overridden on a regular basis in customer projects. Giving it an id makes overriding it less confusing. 