### PR TITLE
fix: added missing kicker resolver for media teaser

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -96,6 +96,7 @@ services:
       arguments:
         - '@Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolverChain'
         - '@atoolo_graphql_search.resolver.asset.resource_symbolic_image_resolver'
+        - '@Atoolo\GraphQL\Search\Resolver\ResourceKickerResolver'
       tags:
         - { name: 'atoolo_graphql_search.resolver' }
 

--- a/src/Resolver/MediaTeaserResolver.php
+++ b/src/Resolver/MediaTeaserResolver.php
@@ -16,7 +16,14 @@ class MediaTeaserResolver implements Resolver
     public function __construct(
         private readonly ResourceAssetResolver $assetResolver,
         private readonly ResourceSymbolicImageResolver $symbolicImageResolver,
+        private readonly ResourceKickerResolver $kickerResolver,
     ) {}
+
+    public function getKicker(
+        MediaTeaser $teaser,
+    ): ?string {
+        return $this->kickerResolver->getKicker($teaser->resource);
+    }
 
     public function getAsset(
         MediaTeaser $teaser,

--- a/test/Resolver/MediaTeaserResolverTest.php
+++ b/test/Resolver/MediaTeaserResolverTest.php
@@ -7,7 +7,7 @@ namespace Atoolo\GraphQL\Search\Test\Resolver;
 use Atoolo\GraphQL\Search\Resolver\Asset\ResourceAssetResolver;
 use Atoolo\GraphQL\Search\Resolver\Asset\ResourceSymbolicImageResolver;
 use Atoolo\GraphQL\Search\Resolver\MediaTeaserResolver;
-use Atoolo\GraphQL\Search\Resolver\ResourceDateResolver;
+use Atoolo\GraphQL\Search\Resolver\ResourceKickerResolver;
 use Atoolo\GraphQL\Search\Types\MediaTeaser;
 use Atoolo\Resource\Resource;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
@@ -24,7 +24,7 @@ class MediaTeaserResolverTest extends TestCase
 
     private ResourceSymbolicImageResolver&MockObject $symbolicImageResolver;
 
-    private ResourceDateResolver&MockObject $dateResolver;
+    private ResourceKickerResolver&MockObject $kickerResolver;
 
     public function setUp(): void
     {
@@ -34,13 +34,13 @@ class MediaTeaserResolverTest extends TestCase
         $this->symbolicImageResolver = $this->createMock(
             ResourceSymbolicImageResolver::class,
         );
-        $this->dateResolver = $this->createMock(
-            ResourceDateResolver::class,
+        $this->kickerResolver = $this->createMock(
+            ResourceKickerResolver::class,
         );
         $this->mediaTeaserResolver = new MediaTeaserResolver(
             $this->assetResolver,
             $this->symbolicImageResolver,
-            $this->dateResolver,
+            $this->kickerResolver,
         );
     }
 
@@ -76,5 +76,22 @@ class MediaTeaserResolverTest extends TestCase
         $args = $this->createStub(ArgumentInterface::class);
 
         $this->mediaTeaserResolver->getSymbolicImage($teaser, $args);
+    }
+
+    public function testGetKicker(): void
+    {
+        $this->kickerResolver->expects($this->once())
+            ->method('getKicker');
+        $teaser = new MediaTeaser(
+            null,
+            null,
+            null,
+            null,
+            null,
+            $this->createStub(Resource::class),
+        );
+        $args = $this->createStub(ArgumentInterface::class);
+
+        $this->mediaTeaserResolver->getKicker($teaser, $args);
     }
 }


### PR DESCRIPTION
Adds a previously missing `KickerResolver` to the `MediaTeaserResolver`