### PR TITLE
refactor: use 'link' instead of 'url' for teasers

### DIFF
--- a/config/graphql/decorators/Teaser.decorator.yaml
+++ b/config/graphql/decorators/Teaser.decorator.yaml
@@ -4,5 +4,9 @@ TeaserDecorator:
   config:
     fields:
       url:
-        type: "String!"
+        type: "String"
         description: Teaser URL
+        deprecationReason: Use field 'link' instead
+      link:
+        type: "Link"
+        description: Teaser Link

--- a/config/graphql/types/Other.type.yml
+++ b/config/graphql/types/Other.type.yml
@@ -124,7 +124,7 @@ Link:
     fields:
       url : { type: "String!" }
       label : { type: "String" }
-      ariaLabel : { type: "String" }
+      accessibilityLabel : { type: "String" }
       description: { type: "String" }
       opensNewWindow: { type: "Boolean!" }
       isExternal: { type: "Boolean!" }

--- a/config/graphql/types/Other.type.yml
+++ b/config/graphql/types/Other.type.yml
@@ -117,3 +117,14 @@ IndexerStatus:
       updated: { type: "Int" }
       errors: { type: "Int" }
       statusLine: { type: "String" }
+
+Link:
+  type: "object"
+  config:
+    fields:
+      url : { type: "String!" }
+      label : { type: "String" }
+      ariaLabel : { type: "String" }
+      description: { type: "String" }
+      opensNewWindow: { type: "Boolean!" }
+      isExternal: { type: "Boolean!" }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -112,22 +112,27 @@ services:
 
   # Factories
 
+  atoolo_graphql_search.factory.link_factory:
+    class: 'Atoolo\GraphQL\Search\Factory\LinkFactory'
+    arguments:
+      - '@atoolo_graphql_search.resolver.url_rewriter'
+
   atoolo_graphql_search.factory.fallback_teaser_factory:
     class: 'Atoolo\GraphQL\Search\Factory\ArticleTeaserFactory'
     arguments:
-      - '@atoolo_graphql_search.resolver.url_rewriter'
+      - '@atoolo_graphql_search.factory.link_factory'
 
   atoolo_graphql_search.factory.media_teaser_factory:
     class: 'Atoolo\GraphQL\Search\Factory\MediaTeaserFactory'
     arguments:
-      - '@atoolo_graphql_search.resolver.url_rewriter'
+      - '@atoolo_graphql_search.factory.link_factory'
     tags:
       - { name: 'atoolo_graphql_search.teaser_factory', objectType: 'media' }
 
   atoolo_graphql_search.factory.embedded_media_teaser_factory:
     class: 'Atoolo\GraphQL\Search\Factory\MediaTeaserFactory'
     arguments:
-      - '@atoolo_graphql_search.resolver.url_rewriter'
+      - '@atoolo_graphql_search.factory.link_factory'
     tags:
       - { name: 'atoolo_graphql_search.teaser_factory', objectType: 'embedded-media' }
 

--- a/src/Factory/ArticleTeaserFactory.php
+++ b/src/Factory/ArticleTeaserFactory.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Atoolo\GraphQL\Search\Factory;
 
-use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
-use Atoolo\GraphQL\Search\Resolver\UrlRewriterType;
 use Atoolo\GraphQL\Search\Types\ArticleTeaser;
 use Atoolo\GraphQL\Search\Types\Teaser;
 use Atoolo\Resource\Resource;
@@ -13,14 +11,13 @@ use Atoolo\Resource\Resource;
 class ArticleTeaserFactory implements TeaserFactory
 {
     public function __construct(
-        private readonly UrlRewriter $urlRewriter,
+        private readonly LinkFactory $linkFactory,
     ) {}
 
     public function create(Resource $resource): Teaser
     {
-        $url = $this->urlRewriter->rewrite(
-            UrlRewriterType::LINK,
-            $resource->location,
+        $link = $this->linkFactory->create(
+            $resource,
         );
 
         $headline = $resource->data->getString(
@@ -30,7 +27,7 @@ class ArticleTeaserFactory implements TeaserFactory
         $text = $resource->data->getString('base.teaser.text');
 
         return new ArticleTeaser(
-            $url,
+            $link,
             $headline,
             $text === '' ? null : $text,
             $resource,

--- a/src/Factory/LinkFactory.php
+++ b/src/Factory/LinkFactory.php
@@ -20,7 +20,7 @@ class LinkFactory
         return new Link(
             $this->getUrl($resource),
             $this->getLabel($resource),
-            $this->getAriaLabel($resource),
+            $this->getAccessibilityLabel($resource),
             $this->getDescription($resource),
             $this->opensNewWindow($resource),
             $this->isExternal($resource),
@@ -51,7 +51,7 @@ class LinkFactory
         );
     }
 
-    protected function getAriaLabel(Resource $resource): ?string
+    protected function getAccessibilityLabel(Resource $resource): ?string
     {
         return $resource->data->has('external.accessibilityLabel')
             ? $resource->data->getString('external.accessibilityLabel')

--- a/src/Factory/LinkFactory.php
+++ b/src/Factory/LinkFactory.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Factory;
+
+use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
+use Atoolo\GraphQL\Search\Resolver\UrlRewriterType;
+use Atoolo\GraphQL\Search\Types\Link;
+use Atoolo\Resource\Resource;
+
+class LinkFactory
+{
+    public function __construct(
+        private readonly UrlRewriter $urlRewriter,
+    ) {}
+
+    public function create(Resource $resource): Link
+    {
+        return new Link(
+            $this->getUrl($resource),
+            $this->getLabel($resource),
+            $this->getAriaLabel($resource),
+            $this->getDescription($resource),
+            $this->opensNewWindow($resource),
+            $this->isExternal($resource),
+        );
+    }
+
+    protected function getUrl(Resource $resource): string
+    {
+        return $this->isMedia($resource)
+            ? $this->urlRewriter->rewrite(
+                UrlRewriterType::MEDIA,
+                $resource->data->getString('mediaUrl'),
+            )
+            : $this->urlRewriter->rewrite(
+                UrlRewriterType::LINK,
+                $resource->location,
+            );
+    }
+
+    protected function getLabel(Resource $resource): ?string
+    {
+        return $resource->data->getString(
+            'external.label',
+            $resource->data->getString(
+                'base.title',
+                $resource->data->getString('name'),
+            ),
+        );
+    }
+
+    protected function getAriaLabel(Resource $resource): ?string
+    {
+        return $resource->data->has('external.accessibilityLabel')
+            ? $resource->data->getString('external.accessibilityLabel')
+            : null;
+    }
+
+    protected function getDescription(Resource $resource): ?string
+    {
+        return $resource->data->has('external.description')
+            ? $resource->data->getString('external.description')
+            : null;
+    }
+
+    protected function opensNewWindow(Resource $resource): bool
+    {
+        return $resource->data->getBool('external.newWindow', false);
+    }
+
+    protected function isExternal(Resource $resource): bool
+    {
+        return $resource->data->getBool('external.external', false);
+    }
+
+    protected function isMedia(Resource $resource): bool
+    {
+        if ($resource->objectType === 'media') {
+            return true;
+        }
+        if ($resource->objectType === 'embedded-media') {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Factory/MediaTeaserFactory.php
+++ b/src/Factory/MediaTeaserFactory.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Atoolo\GraphQL\Search\Factory;
 
-use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
-use Atoolo\GraphQL\Search\Resolver\UrlRewriterType;
 use Atoolo\GraphQL\Search\Types\MediaTeaser;
 use Atoolo\GraphQL\Search\Types\Teaser;
 use Atoolo\Resource\Resource;
 
 class MediaTeaserFactory implements TeaserFactory
 {
-    public function __construct(private readonly UrlRewriter $urlRewriter) {}
+    public function __construct(
+        private readonly LinkFactory $linkFactory,
+    ) {}
 
     public function create(Resource $resource): Teaser
     {
@@ -22,10 +22,10 @@ class MediaTeaserFactory implements TeaserFactory
                 'objectType: ' . $resource->objectType);
         }
 
-        $url = $this->urlRewriter->rewrite(
-            UrlRewriterType::MEDIA,
-            $resource->data->getString('mediaUrl'),
+        $link = $this->linkFactory->create(
+            $resource,
         );
+
         $headline = $resource->data->getString(
             'base.teaser.headline',
             $resource->name,
@@ -35,7 +35,7 @@ class MediaTeaserFactory implements TeaserFactory
         $contentLength = $resource->data->getInt('base.filesize');
 
         return new MediaTeaser(
-            $url,
+            $link,
             $headline,
             $text === '' ? null : $text,
             $contentType,

--- a/src/Factory/NewsTeaserFactory.php
+++ b/src/Factory/NewsTeaserFactory.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Atoolo\GraphQL\Search\Factory;
 
-use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
-use Atoolo\GraphQL\Search\Resolver\UrlRewriterType;
 use Atoolo\GraphQL\Search\Types\NewsTeaser;
 use Atoolo\GraphQL\Search\Types\Teaser;
 use Atoolo\Resource\Resource;
@@ -13,14 +11,13 @@ use Atoolo\Resource\Resource;
 class NewsTeaserFactory implements TeaserFactory
 {
     public function __construct(
-        private readonly UrlRewriter $urlRewriter,
+        private readonly LinkFactory $linkFactory,
     ) {}
 
     public function create(Resource $resource): Teaser
     {
-        $url = $this->urlRewriter->rewrite(
-            UrlRewriterType::LINK,
-            $resource->location,
+        $link = $this->linkFactory->create(
+            $resource,
         );
 
         $headline = $resource->data->getString(
@@ -30,7 +27,7 @@ class NewsTeaserFactory implements TeaserFactory
         $text = $resource->data->getString('base.teaser.text');
 
         return new NewsTeaser(
-            $url,
+            $link,
             $headline,
             $text === '' ? null : $text,
             $resource,

--- a/src/Resolver/Teaser/ArticleTeaserResolver.php
+++ b/src/Resolver/Teaser/ArticleTeaserResolver.php
@@ -23,6 +23,12 @@ class ArticleTeaserResolver implements Resolver
         private readonly ResourceDateTimeResolver $dateResolver,
     ) {}
 
+    public function getUrl(
+        ArticleTeaser $teaser,
+    ): ?string {
+        return $teaser->link?->url;
+    }
+
     public function getKicker(
         ArticleTeaser $teaser,
     ): ?string {

--- a/src/Resolver/Teaser/MediaTeaserResolver.php
+++ b/src/Resolver/Teaser/MediaTeaserResolver.php
@@ -21,6 +21,12 @@ class MediaTeaserResolver implements Resolver
         private readonly ResourceKickerResolver $kickerResolver,
     ) {}
 
+    public function getUrl(
+        MediaTeaser $teaser,
+    ): ?string {
+        return $teaser->link?->url;
+    }
+
     public function getKicker(
         MediaTeaser $teaser,
     ): ?string {

--- a/src/Resolver/Teaser/NewsTeaserResolver.php
+++ b/src/Resolver/Teaser/NewsTeaserResolver.php
@@ -24,6 +24,12 @@ class NewsTeaserResolver implements Resolver
         private readonly ResourceDateTimeResolver $dateResolver,
     ) {}
 
+    public function getUrl(
+        NewsTeaser $teaser,
+    ): ?string {
+        return $teaser->link?->url;
+    }
+
     public function getKicker(
         NewsTeaser $teaser,
     ): ?string {

--- a/src/Types/ArticleTeaser.php
+++ b/src/Types/ArticleTeaser.php
@@ -12,11 +12,11 @@ use Atoolo\Resource\Resource;
 class ArticleTeaser extends Teaser
 {
     public function __construct(
-        ?string $url,
+        ?Link $link,
         public readonly ?string $headline,
         public readonly ?string $text,
         public readonly Resource $resource,
     ) {
-        parent::__construct($url);
+        parent::__construct($link);
     }
 }

--- a/src/Types/Link.php
+++ b/src/Types/Link.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Types;
+
+/**
+ * @codeCoverageIgnore
+ */
+class Link
+{
+    public function __construct(
+        public readonly string $url,
+        public readonly ?string $label = null,
+        public readonly ?string $ariaLabel = null,
+        public readonly ?string $description = null,
+        public readonly bool $opensNewWindow = false,
+        public readonly bool $isExternal = false,
+    ) {}
+}

--- a/src/Types/Link.php
+++ b/src/Types/Link.php
@@ -12,7 +12,7 @@ class Link
     public function __construct(
         public readonly string $url,
         public readonly ?string $label = null,
-        public readonly ?string $ariaLabel = null,
+        public readonly ?string $accessibilityLabel = null,
         public readonly ?string $description = null,
         public readonly bool $opensNewWindow = false,
         public readonly bool $isExternal = false,

--- a/src/Types/MediaTeaser.php
+++ b/src/Types/MediaTeaser.php
@@ -12,13 +12,13 @@ use Atoolo\Resource\Resource;
 class MediaTeaser extends Teaser
 {
     public function __construct(
-        ?string $url,
+        ?Link $link,
         public readonly ?string $headline,
         public readonly ?string $text,
         public readonly ?string $contentType,
         public readonly ?int $contentLength,
         public readonly Resource $resource,
     ) {
-        parent::__construct($url);
+        parent::__construct($link);
     }
 }

--- a/src/Types/NewsTeaser.php
+++ b/src/Types/NewsTeaser.php
@@ -12,11 +12,11 @@ use Atoolo\Resource\Resource;
 class NewsTeaser extends Teaser
 {
     public function __construct(
-        ?string $url,
+        ?Link $link,
         public readonly ?string $headline,
         public readonly ?string $text,
         public readonly Resource $resource,
     ) {
-        parent::__construct($url);
+        parent::__construct($link);
     }
 }

--- a/src/Types/Teaser.php
+++ b/src/Types/Teaser.php
@@ -10,6 +10,6 @@ namespace Atoolo\GraphQL\Search\Types;
 abstract class Teaser
 {
     public function __construct(
-        public readonly ?string $url,
+        public readonly ?Link $link,
     ) {}
 }

--- a/test/Factory/ArticleTeaserFactoryTest.php
+++ b/test/Factory/ArticleTeaserFactoryTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Test\Factory;
 
 use Atoolo\GraphQL\Search\Factory\ArticleTeaserFactory;
-use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
+use Atoolo\GraphQL\Search\Factory\LinkFactory;
+use Atoolo\GraphQL\Search\Types\Link;
 use Atoolo\Resource\DataBag;
 use Atoolo\Resource\Resource;
 use Atoolo\Resource\ResourceLanguage;
@@ -17,17 +18,17 @@ class ArticleTeaserFactoryTest extends TestCase
 {
     private ArticleTeaserFactory $factory;
 
-    private UrlRewriter $urlRewriter;
+    private LinkFactory $linkFactory;
 
     public function setUp(): void
     {
-        $this->urlRewriter = $this->createStub(UrlRewriter::class);
+        $this->linkFactory = $this->createStub(LinkFactory::class);
         $this->factory = new ArticleTeaserFactory(
-            $this->urlRewriter,
+            $this->linkFactory,
         );
     }
 
-    public function testUrl(): void
+    public function testLink(): void
     {
         $resource = new Resource(
             'originalUrl',
@@ -37,16 +38,16 @@ class ArticleTeaserFactoryTest extends TestCase
             ResourceLanguage::default(),
             new DataBag([]),
         );
-
-        $this->urlRewriter->method('rewrite')
-            ->willReturn('rewrittenUrl');
+        $link = new Link('url');
+        $this->linkFactory->method('create')
+            ->willReturn($link);
 
         $teaser = $this->factory->create($resource);
 
         $this->assertEquals(
-            'rewrittenUrl',
-            $teaser->url,
-            'unexpected url',
+            $link,
+            $teaser->link,
+            'unexpected link',
         );
     }
 

--- a/test/Factory/LinkFactoryTest.php
+++ b/test/Factory/LinkFactoryTest.php
@@ -51,7 +51,7 @@ class LinkFactoryTest extends TestCase
 
         $this->assertEquals($url, $link->url);
         $this->assertEquals($title, $link->label);
-        $this->assertNull($link->ariaLabel);
+        $this->assertNull($link->accessibilityLabel);
         $this->assertNull($link->description);
         $this->assertFalse($link->opensNewWindow);
         $this->assertFalse($link->isExternal);
@@ -123,7 +123,7 @@ class LinkFactoryTest extends TestCase
 
         $this->assertEquals($url, $link->url);
         $this->assertEquals($label, $link->label);
-        $this->assertEquals($accessibilityLabel, $link->ariaLabel);
+        $this->assertEquals($accessibilityLabel, $link->accessibilityLabel);
         $this->assertEquals($description, $link->description);
         $this->assertTrue($link->opensNewWindow);
         $this->assertTrue($link->isExternal);

--- a/test/Factory/LinkFactoryTest.php
+++ b/test/Factory/LinkFactoryTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Test\Factory;
+
+use Atoolo\GraphQL\Search\Factory\ImageFactory;
+use Atoolo\GraphQL\Search\Factory\LinkFactory;
+use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
+use Atoolo\GraphQL\Search\Resolver\UrlRewriterType;
+use Atoolo\GraphQL\Search\Types\ImageCharacteristic;
+use Atoolo\Resource\DataBag;
+use Atoolo\Resource\Resource;
+use Atoolo\Resource\ResourceLanguage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+#[CoversClass(LinkFactory::class)]
+class LinkFactoryTest extends TestCase
+{
+    private LinkFactory $factory;
+
+    private UrlRewriter&MockObject $urlRewriter;
+
+    public function setUp(): void
+    {
+        $this->urlRewriter = $this->createStub(UrlRewriter::class);
+        $this->factory = new LinkFactory(
+            $this->urlRewriter,
+        );
+    }
+
+    public function testCreate(): void
+    {
+        $url = '/some_url.php';
+        $title = 'some_title';
+        $resource = $this->createResource([
+            'url' => $url,
+            'base' => [
+                'title' => $title,
+            ],
+        ]);
+        $this->urlRewriter
+            ->expects($this->atLeastOnce())
+            ->method('rewrite')
+            ->willReturn($url);
+        $link = $this->factory->create($resource);
+
+        $this->assertEquals($url, $link->url);
+        $this->assertEquals($title, $link->label);
+        $this->assertNull($link->ariaLabel);
+        $this->assertNull($link->description);
+        $this->assertFalse($link->opensNewWindow);
+        $this->assertFalse($link->isExternal);
+    }
+
+    public function testCreateWithoutTitle(): void
+    {
+        $url = '/some_url.php';
+        $name = 'some_name';
+        $resource = $this->createResource([
+            'url' => $url,
+            'name' => $name,
+        ]);
+        $this->urlRewriter
+            ->expects($this->atLeastOnce())
+            ->method('rewrite')
+            ->willReturn($url);
+        $link = $this->factory->create($resource);
+        $this->assertEquals($name, $link->label);
+    }
+
+    public function testCreateWithMediaResource(): void
+    {
+        $mediaUrl = '/some_url.jpg';
+        $resource = $this->createResource([
+            'objectType' => 'media',
+            'mediaUrl' => $mediaUrl,
+        ]);
+        $resource2 = $this->createResource([
+            'objectType' => 'embedded-media',
+            'mediaUrl' => $mediaUrl,
+        ]);
+        $this->urlRewriter
+            ->expects($this->atLeastOnce())
+            ->method('rewrite')
+            ->with(UrlRewriterType::MEDIA, $mediaUrl)
+            ->willReturn($mediaUrl);
+        $link = $this->factory->create($resource);
+        $this->assertEquals($mediaUrl, $link->url);
+
+        $link2 = $this->factory->create($resource2);
+        $this->assertEquals($mediaUrl, $link2->url);
+    }
+
+    public function testCreateWithExternal(): void
+    {
+        $url = '/some_url.php';
+        $label = 'external_label';
+        $accessibilityLabel = 'accessibility_label';
+        $description = 'description';
+        $resource = $this->createResource([
+            'url' => $url,
+            'base' => [
+                'title' => 'some_title',
+            ],
+            'external' => [
+                'label' => $label,
+                'accessibilityLabel' => $accessibilityLabel,
+                'description' => $description,
+                'newWindow' => true,
+                'external' => true,
+            ],
+        ]);
+        $this->urlRewriter
+            ->expects($this->atLeastOnce())
+            ->method('rewrite')
+            ->willReturn($url);
+        $link = $this->factory->create($resource);
+
+        $this->assertEquals($url, $link->url);
+        $this->assertEquals($label, $link->label);
+        $this->assertEquals($accessibilityLabel, $link->ariaLabel);
+        $this->assertEquals($description, $link->description);
+        $this->assertTrue($link->opensNewWindow);
+        $this->assertTrue($link->isExternal);
+    }
+
+
+
+    private function createResource(array $data): Resource
+    {
+        return new Resource(
+            $data['url'] ?? '',
+            $data['id'] ?? '',
+            $data['name'] ?? '',
+            $data['objectType'] ?? '',
+            ResourceLanguage::default(),
+            new DataBag($data),
+        );
+    }
+}

--- a/test/Factory/NewsTeaserFactoryTest.php
+++ b/test/Factory/NewsTeaserFactoryTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Atoolo\GraphQL\Search\Test\Factory;
 
+use Atoolo\GraphQL\Search\Factory\LinkFactory;
 use Atoolo\GraphQL\Search\Factory\NewsTeaserFactory;
-use Atoolo\GraphQL\Search\Resolver\UrlRewriter;
+use Atoolo\GraphQL\Search\Types\Link;
 use Atoolo\Resource\DataBag;
 use Atoolo\Resource\Resource;
 use Atoolo\Resource\ResourceLanguage;
@@ -17,17 +18,17 @@ class NewsTeaserFactoryTest extends TestCase
 {
     private NewsTeaserFactory $factory;
 
-    private UrlRewriter $urlRewriter;
+    private LinkFactory $linkFactory;
 
     public function setUp(): void
     {
-        $this->urlRewriter = $this->createStub(UrlRewriter::class);
+        $this->linkFactory = $this->createStub(LinkFactory::class);
         $this->factory = new NewsTeaserFactory(
-            $this->urlRewriter,
+            $this->linkFactory,
         );
     }
 
-    public function testUrl(): void
+    public function testLink(): void
     {
         $resource = new Resource(
             'originalUrl',
@@ -37,16 +38,16 @@ class NewsTeaserFactoryTest extends TestCase
             ResourceLanguage::default(),
             new DataBag([]),
         );
-
-        $this->urlRewriter->method('rewrite')
-            ->willReturn('rewrittenUrl');
+        $link = new Link('url');
+        $this->linkFactory->method('create')
+            ->willReturn($link);
 
         $teaser = $this->factory->create($resource);
 
         $this->assertEquals(
-            'rewrittenUrl',
-            $teaser->url,
-            'unexpected url',
+            $link,
+            $teaser->link,
+            'unexpected link',
         );
     }
 

--- a/test/Resolver/ResolverMapRegistryTest.php
+++ b/test/Resolver/ResolverMapRegistryTest.php
@@ -8,6 +8,7 @@ use ArrayObject;
 use Atoolo\GraphQL\Search\Resolver\ResolverMapRegistry;
 use Atoolo\GraphQL\Search\Types\ArticleTeaser;
 use Atoolo\GraphQL\Search\Types\Image;
+use Atoolo\GraphQL\Search\Types\Link;
 use Atoolo\Resource\Resource;
 use GraphQL\Type\Definition\ResolveInfo;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
@@ -70,7 +71,7 @@ class ResolverMapRegistryTest extends TestCase
             new DummyTeaserGetterResolver(),
         ]);
         $articleTeaser = new ArticleTeaser(
-            'url',
+            new Link('url'),
             'headline',
             'text',
             $this->createStub(Resource::class),
@@ -99,7 +100,7 @@ class ResolverMapRegistryTest extends TestCase
         $fn = $registry->resolve('Teaser', ResolverMapInterface::RESOLVE_TYPE);
 
         $teaser = new ArticleTeaser(
-            'url',
+            new Link('url'),
             'headline',
             'text',
             $this->createStub(Resource::class),

--- a/test/Resolver/Teaser/ArticleTeaserResolverTest.php
+++ b/test/Resolver/Teaser/ArticleTeaserResolverTest.php
@@ -10,6 +10,7 @@ use Atoolo\GraphQL\Search\Resolver\Resource\ResourceKickerResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceSymbolicImageResolver;
 use Atoolo\GraphQL\Search\Resolver\Teaser\ArticleTeaserResolver;
 use Atoolo\GraphQL\Search\Types\ArticleTeaser;
+use Atoolo\GraphQL\Search\Types\Link;
 use Atoolo\Resource\Resource;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -55,12 +56,29 @@ class ArticleTeaserResolverTest extends TestCase
         );
     }
 
+    public function testGetUrl(): void
+    {
+        $url = '/some_url.php';
+        $link = new Link($url);
+        $teaser = new ArticleTeaser(
+            $link,
+            '',
+            '',
+            $this->createStub(Resource::class),
+        );
+        $this->assertEquals(
+            $url,
+            $this->resolver->getUrl($teaser),
+            'getUrl should return the url of the teaser link',
+        );
+    }
+
     public function testGetDate(): void
     {
         $this->dateTimeResolver->expects($this->once())
             ->method('getDate');
         $teaser = new ArticleTeaser(
-            '',
+            null,
             '',
             '',
             $this->createStub(Resource::class),
@@ -74,7 +92,7 @@ class ArticleTeaserResolverTest extends TestCase
         $this->assetResolver->expects($this->once())
             ->method('getAsset');
         $teaser = new ArticleTeaser(
-            '',
+            null,
             '',
             '',
             $this->createStub(Resource::class),
@@ -89,7 +107,7 @@ class ArticleTeaserResolverTest extends TestCase
         $this->symbolicImageResolver->expects($this->once())
             ->method('getSymbolicImage');
         $teaser = new ArticleTeaser(
-            '',
+            null,
             '',
             '',
             $this->createStub(Resource::class),
@@ -104,7 +122,7 @@ class ArticleTeaserResolverTest extends TestCase
         $this->kickerResolver->expects($this->once())
             ->method('getKicker');
         $teaser = new ArticleTeaser(
-            '',
+            null,
             '',
             '',
             $this->createStub(Resource::class),

--- a/test/Resolver/Teaser/MediaTeaserResolverTest.php
+++ b/test/Resolver/Teaser/MediaTeaserResolverTest.php
@@ -8,6 +8,7 @@ use Atoolo\GraphQL\Search\Resolver\Resource\ResourceAssetResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceKickerResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceSymbolicImageResolver;
 use Atoolo\GraphQL\Search\Resolver\Teaser\MediaTeaserResolver;
+use Atoolo\GraphQL\Search\Types\Link;
 use Atoolo\GraphQL\Search\Types\MediaTeaser;
 use Atoolo\Resource\Resource;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
@@ -41,6 +42,25 @@ class MediaTeaserResolverTest extends TestCase
             $this->assetResolver,
             $this->symbolicImageResolver,
             $this->kickerResolver,
+        );
+    }
+
+    public function testGetUrl(): void
+    {
+        $url = '/some_url.php';
+        $link = new Link($url);
+        $teaser = new MediaTeaser(
+            $link,
+            null,
+            null,
+            null,
+            null,
+            $this->createStub(Resource::class),
+        );
+        $this->assertEquals(
+            $url,
+            $this->mediaTeaserResolver->getUrl($teaser),
+            'getUrl should return the url of the teaser link',
         );
     }
 

--- a/test/Resolver/Teaser/NewsTeaserResolverTest.php
+++ b/test/Resolver/Teaser/NewsTeaserResolverTest.php
@@ -9,6 +9,7 @@ use Atoolo\GraphQL\Search\Resolver\Resource\ResourceDateTimeResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceKickerResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceSymbolicImageResolver;
 use Atoolo\GraphQL\Search\Resolver\Teaser\NewsTeaserResolver;
+use Atoolo\GraphQL\Search\Types\Link;
 use Atoolo\GraphQL\Search\Types\NewsTeaser;
 use Atoolo\Resource\Resource;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
@@ -55,12 +56,29 @@ class NewsTeaserResolverTest extends TestCase
         );
     }
 
+    public function testGetUrl(): void
+    {
+        $url = '/some_url.php';
+        $link = new Link($url);
+        $teaser = new NewsTeaser(
+            $link,
+            '',
+            '',
+            $this->createStub(Resource::class),
+        );
+        $this->assertEquals(
+            $url,
+            $this->resolver->getUrl($teaser),
+            'getUrl should return the url of the teaser link',
+        );
+    }
+
     public function testGetDate(): void
     {
         $this->dateTimeResolver->expects($this->once())
             ->method('getDate');
         $teaser = new NewsTeaser(
-            '',
+            null,
             '',
             '',
             $this->createStub(Resource::class),
@@ -74,7 +92,7 @@ class NewsTeaserResolverTest extends TestCase
         $this->assetResolver->expects($this->once())
             ->method('getAsset');
         $teaser = new NewsTeaser(
-            '',
+            null,
             '',
             '',
             $this->createStub(Resource::class),
@@ -89,7 +107,7 @@ class NewsTeaserResolverTest extends TestCase
         $this->symbolicImageResolver->expects($this->once())
             ->method('getSymbolicImage');
         $teaser = new NewsTeaser(
-            '',
+            null,
             '',
             '',
             $this->createStub(Resource::class),
@@ -104,7 +122,7 @@ class NewsTeaserResolverTest extends TestCase
         $this->kickerResolver->expects($this->once())
             ->method('getKicker');
         $teaser = new NewsTeaser(
-            '',
+            null,
             '',
             '',
             $this->createStub(Resource::class),


### PR DESCRIPTION
- adds new graphql type "Link" 
- teasers now use this Link type for their url
- the graphql type "Teaser" still has the field 'url', but its marked as deprecated