### PR TITLE
feat: add argument 'variant' to symbolicAsset

### DIFF
--- a/config/graphql/decorators/ArticleTeaser.decorator.yaml
+++ b/config/graphql/decorators/ArticleTeaser.decorator.yaml
@@ -23,8 +23,12 @@ ArticleTeaserDecorator:
         args:
           variant:
             type: "String"
-            description: The teaser variant is used to decide which image format is to be returned.
+            description: The asset variant is used to decide which image format is to be returned.
         description: Teaser asset can be e.g. pictures or videos
       symbolicAsset:
         type: "Asset"
         description: symbolic asset associated with the teaser
+        args:
+          variant:
+            type: "String"
+            description: The asset variant is used to decide which image format is to be returned.

--- a/config/graphql/decorators/MediaTeaser.decorator.yml
+++ b/config/graphql/decorators/MediaTeaser.decorator.yml
@@ -15,8 +15,12 @@ MediaTeaserDecorator:
         args:
           variant:
             type: "String!"
-            description: The teaser variant is used to decide which image format is to be returned.
+            description: The asset variant is used to decide which image format is to be returned.
         description: Teaser asset can be e.g. pictures or videos
       symbolicAsset:
         type: "Asset"
         description: symbolic asset associated with the teaser
+        args:
+          variant:
+            type: "String"
+            description: The asset variant is used to decide which image format is to be returned.

--- a/config/graphql/decorators/NewsTeaser.decorator.yaml
+++ b/config/graphql/decorators/NewsTeaser.decorator.yaml
@@ -28,3 +28,7 @@ NewsTeaserDecorator:
       symbolicAsset:
         type: "Asset"
         description: symbolic asset associated with the teaser
+        args:
+          variant:
+            type: "String"
+            description: The asset variant is used to decide which image format is to be returned.

--- a/config/graphql/types/Other.type.yml
+++ b/config/graphql/types/Other.type.yml
@@ -18,6 +18,9 @@ Resource:
             type: "String"
       symbolicAsset:
         type: "Asset"
+        args:
+          variant:
+            type: "String"
       explain:
         type: "ResultExplain"
 


### PR DESCRIPTION
Of course I forgot something in the last PR. The field `symbolicAsset`, just like `asset`, needs to have an argument `variant`.
The resolvers/factories already expect the argument, the only thing that was missing is the schema definition.
