### PR TITLE
feat: added action links

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
             "@analyse:compatibilitycheck"
         ],
         "analyse:compatibilitycheck": "./vendor/bin/phpcs --standard=./phpcs.compatibilitycheck.xml",
-	"analyse:phpcsfixer": "./tools/php-cs-fixer check --diff --show-progress=dots",
+        "analyse:phpcsfixer": "./tools/php-cs-fixer check --diff --show-progress=dots",
         "analyse:phplint": "./tools/phplint",
         "analyse:phpstan": "./tools/phpstan analyse",
         "cs-fix": [

--- a/config/graphql/decorators/ArticleTeaser.decorator.yaml
+++ b/config/graphql/decorators/ArticleTeaser.decorator.yaml
@@ -32,3 +32,7 @@ ArticleTeaserDecorator:
           variant:
             type: "String"
             description: The asset variant is used to decide which image format is to be returned.
+      actions:
+        type: "[Link!]!"
+        description: additional, context dependent links
+

--- a/config/graphql/decorators/MediaTeaser.decorator.yml
+++ b/config/graphql/decorators/MediaTeaser.decorator.yml
@@ -24,3 +24,6 @@ MediaTeaserDecorator:
           variant:
             type: "String"
             description: The asset variant is used to decide which image format is to be returned.
+      actions:
+        type: "[Link!]!"
+        description: additional, context dependent links

--- a/config/graphql/decorators/NewsTeaser.decorator.yaml
+++ b/config/graphql/decorators/NewsTeaser.decorator.yaml
@@ -32,3 +32,6 @@ NewsTeaserDecorator:
           variant:
             type: "String"
             description: The asset variant is used to decide which image format is to be returned.
+      actions:
+        type: "[Link!]!"
+        description: additional, context dependent links

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -83,6 +83,13 @@ services:
     tags:
       - { name: 'atoolo_graphql_search.resolver' }
 
+  atoolo_graphql_search.resolver.resource.resource_action_link_resolver:
+    class: Atoolo\GraphQL\Search\Resolver\Resource\ResourceActionLinkResolver
+    arguments:
+      - !tagged_iterator { tag: 'atoolo_graphql_search.action_link_factory' }
+    tags:
+      - { name: 'atoolo_graphql_search.resolver' }
+
   # Teaser resolvers
 
   atoolo_graphql_search.resolver.teaser.article_teaser_resolver:
@@ -92,6 +99,7 @@ services:
       - '@atoolo_graphql_search.resolver.resource.resource_symbolic_asset_resolver'
       - '@atoolo_graphql_search.resolver.resource.resource_kicker_resolver'
       - '@atoolo_graphql_search.resolver.resource.resource_datetime_resolver'
+      - '@atoolo_graphql_search.resolver.resource.resource_action_link_resolver'
     tags:
       - { name: 'atoolo_graphql_search.resolver' }
 
@@ -102,6 +110,7 @@ services:
       - '@atoolo_graphql_search.resolver.resource.resource_symbolic_asset_resolver'
       - '@atoolo_graphql_search.resolver.resource.resource_kicker_resolver'
       - '@atoolo_graphql_search.resolver.resource.resource_datetime_resolver'
+      - '@atoolo_graphql_search.resolver.resource.resource_action_link_resolver'
     tags:
       - { name: 'atoolo_graphql_search.resolver' }
 
@@ -111,6 +120,7 @@ services:
       - '@atoolo_graphql_search.resolver.resource.resource_asset_resolver'
       - '@atoolo_graphql_search.resolver.resource.resource_symbolic_asset_resolver'
       - '@atoolo_graphql_search.resolver.resource.resource_kicker_resolver'
+      - '@atoolo_graphql_search.resolver.resource.resource_action_link_resolver'
     tags:
       - { name: 'atoolo_graphql_search.resolver' }
 

--- a/src/Factory/ActionLinkFactory.php
+++ b/src/Factory/ActionLinkFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Factory;
+
+use Atoolo\GraphQL\Search\Types\Link;
+use Atoolo\Resource\Resource;
+
+interface ActionLinkFactory
+{
+    /**
+     * @return Link[]
+     */
+    public function create(
+        Resource $resource,
+    ): array;
+}

--- a/src/Resolver/Resource/ResourceActionLinkResolver.php
+++ b/src/Resolver/Resource/ResourceActionLinkResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Resolver\Resource;
+
+use Atoolo\GraphQL\Search\Factory\ActionLinkFactory;
+use Atoolo\GraphQL\Search\Resolver\Resolver;
+use Atoolo\GraphQL\Search\Types\Link;
+use Atoolo\Resource\Resource;
+
+class ResourceActionLinkResolver implements Resolver
+{
+    /**
+     * @param array<ActionLinkFactory> $factories
+     */
+    public function __construct(
+        private readonly iterable $factories,
+    ) {}
+
+    /**
+     * @return Link[]
+     */
+    public function getActionLinks(
+        Resource $resource,
+    ): array {
+        $links = [];
+        foreach ($this->factories as $factory) {
+            foreach ($factory->create($resource) as $createdLink) {
+                if ($createdLink !== null) {
+                    $links[] = $createdLink;
+                }
+            }
+        }
+        return $links;
+    }
+}

--- a/src/Resolver/Teaser/ArticleTeaserResolver.php
+++ b/src/Resolver/Teaser/ArticleTeaserResolver.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Resolver\Teaser;
 
 use Atoolo\GraphQL\Search\Resolver\Resolver;
+use Atoolo\GraphQL\Search\Resolver\Resource\ResourceActionLinkResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceAssetResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceDateTimeResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceKickerResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceSymbolicAssetResolver;
 use Atoolo\GraphQL\Search\Types\ArticleTeaser;
 use Atoolo\GraphQL\Search\Types\Asset;
+use Atoolo\GraphQL\Search\Types\Link;
 use DateTime;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 
@@ -21,6 +23,7 @@ class ArticleTeaserResolver implements Resolver
         private readonly ResourceSymbolicAssetResolver $symbolicAssetResolver,
         private readonly ResourceKickerResolver $kickerResolver,
         private readonly ResourceDateTimeResolver $dateResolver,
+        private readonly ResourceActionLinkResolver $actionLinkResolver,
     ) {}
 
     public function getUrl(
@@ -54,5 +57,16 @@ class ArticleTeaserResolver implements Resolver
     ): ?Asset {
         return $this->symbolicAssetResolver
             ->getSymbolicAsset($teaser->resource, $args);
+    }
+
+    /**
+     * @return Link[]
+     */
+    public function getActions(
+        ArticleTeaser $teaser,
+        ArgumentInterface $args,
+    ): array {
+        return $this->actionLinkResolver
+            ->getActionLinks($teaser->resource);
     }
 }

--- a/src/Resolver/Teaser/MediaTeaserResolver.php
+++ b/src/Resolver/Teaser/MediaTeaserResolver.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Resolver\Teaser;
 
 use Atoolo\GraphQL\Search\Resolver\Resolver;
+use Atoolo\GraphQL\Search\Resolver\Resource\ResourceActionLinkResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceAssetResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceKickerResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceSymbolicAssetResolver;
 use Atoolo\GraphQL\Search\Types\Asset;
+use Atoolo\GraphQL\Search\Types\Link;
 use Atoolo\GraphQL\Search\Types\MediaTeaser;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 
@@ -18,6 +20,7 @@ class MediaTeaserResolver implements Resolver
         private readonly ResourceAssetResolver $assetResolver,
         private readonly ResourceSymbolicAssetResolver $symbolicAssetResolver,
         private readonly ResourceKickerResolver $kickerResolver,
+        private readonly ResourceActionLinkResolver $actionLinkResolver,
     ) {}
 
     public function getUrl(
@@ -45,5 +48,16 @@ class MediaTeaserResolver implements Resolver
     ): ?Asset {
         return $this->symbolicAssetResolver
             ->getSymbolicAsset($teaser->resource, $args);
+    }
+
+    /**
+     * @return Link[]
+     */
+    public function getActions(
+        MediaTeaser $teaser,
+        ArgumentInterface $args,
+    ): array {
+        return $this->actionLinkResolver
+            ->getActionLinks($teaser->resource);
     }
 }

--- a/src/Resolver/Teaser/NewsTeaserResolver.php
+++ b/src/Resolver/Teaser/NewsTeaserResolver.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Resolver\Teaser;
 
 use Atoolo\GraphQL\Search\Resolver\Resolver;
+use Atoolo\GraphQL\Search\Resolver\Resource\ResourceActionLinkResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceAssetResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceDateTimeResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceKickerResolver;
 use Atoolo\GraphQL\Search\Resolver\Resource\ResourceSymbolicAssetResolver;
 use Atoolo\GraphQL\Search\Types\Asset;
+use Atoolo\GraphQL\Search\Types\Link;
 use Atoolo\GraphQL\Search\Types\NewsTeaser;
 use DateTime;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
@@ -21,6 +23,7 @@ class NewsTeaserResolver implements Resolver
         private readonly ResourceSymbolicAssetResolver $symbolicAssetResolver,
         private readonly ResourceKickerResolver $kickerResolver,
         private readonly ResourceDateTimeResolver $dateResolver,
+        private readonly ResourceActionLinkResolver $actionLinkResolver,
     ) {}
 
     public function getUrl(
@@ -54,5 +57,16 @@ class NewsTeaserResolver implements Resolver
     ): ?Asset {
         return $this->symbolicAssetResolver
             ->getSymbolicAsset($teaser->resource, $args);
+    }
+
+    /**
+     * @return Link[]
+     */
+    public function getActions(
+        NewsTeaser $teaser,
+        ArgumentInterface $args,
+    ): array {
+        return $this->actionLinkResolver
+            ->getActionLinks($teaser->resource);
     }
 }


### PR DESCRIPTION
Adds action links to teasers. 

This done by calling a `ResourceActionLinkResolver` which then iterates over all registered `ActionLinkFactory`s and returns all `Link`s that are not null.
Currently, there are no registered ActionLinkFactorys, so the array remains empty.

