### PR TITLE
feat: remove sort criteria 'headline'

### DIFF
--- a/src/Input/InputSortCriteria.php
+++ b/src/Input/InputSortCriteria.php
@@ -17,9 +17,6 @@ class InputSortCriteria
     public ?SortDirection $name = null;
 
     #[GQL\Field(type:"SortDirection")]
-    public ?SortDirection $headline = null;
-
-    #[GQL\Field(type:"SortDirection")]
     public ?SortDirection $date = null;
 
     #[GQL\Field(type:"SortDirection")]

--- a/src/Query/SortCriteriaFactory.php
+++ b/src/Query/SortCriteriaFactory.php
@@ -9,7 +9,6 @@ use Atoolo\GraphQL\Search\Types\SortDirection;
 use Atoolo\Search\Dto\Search\Query\Sort\Criteria;
 use Atoolo\Search\Dto\Search\Query\Sort\Date;
 use Atoolo\Search\Dto\Search\Query\Sort\Direction;
-use Atoolo\Search\Dto\Search\Query\Sort\Headline;
 use Atoolo\Search\Dto\Search\Query\Sort\Name;
 use Atoolo\Search\Dto\Search\Query\Sort\Natural;
 use Atoolo\Search\Dto\Search\Query\Sort\Score;
@@ -22,11 +21,6 @@ class SortCriteriaFactory
         if (isset($criteria->name)) {
             $direction = $this->mapDirection($criteria->name);
             return new Name($direction);
-        }
-
-        if (isset($criteria->headline)) {
-            $direction = $this->mapDirection($criteria->headline);
-            return new Headline($direction);
         }
 
         if (isset($criteria->date)) {

--- a/test/Query/SortCriteriaFactoryTest.php
+++ b/test/Query/SortCriteriaFactoryTest.php
@@ -9,7 +9,6 @@ use Atoolo\GraphQL\Search\Query\SortCriteriaFactory;
 use Atoolo\GraphQL\Search\Types\SortDirection;
 use Atoolo\Search\Dto\Search\Query\Sort\Date;
 use Atoolo\Search\Dto\Search\Query\Sort\Direction;
-use Atoolo\Search\Dto\Search\Query\Sort\Headline;
 use Atoolo\Search\Dto\Search\Query\Sort\Name;
 use Atoolo\Search\Dto\Search\Query\Sort\Natural;
 use Atoolo\Search\Dto\Search\Query\Sort\Score;
@@ -31,21 +30,6 @@ class SortCriteriaFactoryTest extends TestCase
             new Name(Direction::ASC),
             $sort,
             'name sort expected',
-        );
-    }
-
-    public function testCreateWithSortHeadline(): void
-    {
-        $criteria = $this->createSearchInputWithSort('headline');
-
-        $factory = new SortCriteriaFactory();
-
-        $sort = $factory->create($criteria);
-
-        $this->assertEquals(
-            new Headline(Direction::ASC),
-            $sort,
-            'headline sort expected',
         );
     }
 


### PR DESCRIPTION
This criteria is currently obsolete. "natural" should be used instead.

Refs: https://github.com/sitepark/atoolo-search-bundle/pull/16