### PR TITLE
feat: query input field urlBasePath for rewriter-context

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=8.1 <8.5.0",
         "ext-sysvsem": "*",
         "atoolo/resource-bundle": "^1.2",
-        "atoolo/rewrite-bundle": "^1.0",
+        "atoolo/rewrite-bundle": "dev-main",
         "atoolo/search-bundle": "^1.7",
         "overblog/graphql-bundle": "^1.0",
         "symfony/config": "^6.3 || ^7.0",

--- a/config/graphql.yaml
+++ b/config/graphql.yaml
@@ -3,6 +3,8 @@ overblog_graphql:
     exceptions:
       errors:
         - "InvalidArgumentException"
+        - "Atoolo\\Resource\\Exception\\ResourceNotFoundException"
+        - "Atoolo\\Resource\\Exception\\InvalidResourceException"
   definitions:
     schema:
       query: RootQuery

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,6 +7,7 @@ services:
     public: true
     arguments:
       - '@atoolo_search.search'
+      - '@atoolo_rewrite.url_rewrite_context'
 
   Atoolo\GraphQL\Search\Query\MoreLikeThis:
     public: true

--- a/src/Factory/ImageFactory.php
+++ b/src/Factory/ImageFactory.php
@@ -108,10 +108,7 @@ class ImageFactory implements AssetFactory
         }
 
         $sources = [];
-        if (
-            isset($imageData['variants'][$variant]) &&
-            is_array($imageData['variants'][$variant])
-        ) {
+        if (isset($imageData['variants'][$variant])) {
             $sources = $this->toImageSourceList(
                 $resource->lang,
                 $variant,

--- a/src/Input/MoreLikeThisInput.php
+++ b/src/Input/MoreLikeThisInput.php
@@ -16,6 +16,9 @@ class MoreLikeThisInput
     public string $id;
 
     #[GQL\Field(type: "String")]
+    public ?string $urlBasePath = null;
+
+    #[GQL\Field(type: "String")]
     public ?string $lang = null;
 
     /**

--- a/src/Input/SearchInput.php
+++ b/src/Input/SearchInput.php
@@ -26,6 +26,9 @@ class SearchInput
     #[GQL\Field(type: "String")]
     public ?string $lang = null;
 
+    #[GQL\Field(type: "String")]
+    public ?string $urlBasePath = null;
+
     #[GQL\Field(type: "QueryOperator")]
     public ?QueryOperator $defaultQueryOperator = null;
 

--- a/src/Query/MoreLikeThis.php
+++ b/src/Query/MoreLikeThis.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Query;
 
 use Atoolo\GraphQL\Search\Input\MoreLikeThisInput;
+use Atoolo\Rewrite\Service\UrlRewriteContext;
 use Atoolo\Search\Dto\Search\Result\SearchResult;
 use Overblog\GraphQLBundle\Annotation as GQL;
 
@@ -15,6 +16,7 @@ class MoreLikeThis
 
     public function __construct(
         private readonly \Atoolo\Search\MoreLikeThis $moreLikeThis,
+        private readonly UrlRewriteContext $urlRewriteContext,
     ) {
         $this->factory = new MoreLikeThisQueryFactory();
     }
@@ -22,6 +24,9 @@ class MoreLikeThis
     #[GQL\Query(name: 'moreLikeThis', type: 'SearchResult!')]
     public function moreLikeThis(MoreLikeThisInput $input): SearchResult
     {
+        if ($input->urlBasePath !== null) {
+            $this->urlRewriteContext->setBasePath($input->urlBasePath);
+        }
         $query = $this->factory->create($input);
         return $this->moreLikeThis->moreLikeThis($query);
     }

--- a/src/Query/Search.php
+++ b/src/Query/Search.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Query;
 
 use Atoolo\GraphQL\Search\Input\SearchInput;
+use Atoolo\Rewrite\Service\UrlRewriteContext;
 use Atoolo\Search\Dto\Search\Result\SearchResult;
 use Exception;
 use Overblog\GraphQLBundle\Annotation as GQL;
@@ -17,6 +18,7 @@ class Search
 
     public function __construct(
         private readonly \Atoolo\Search\Search $search,
+        private readonly UrlRewriteContext $urlRewriteContext,
     ) {
         $this->factory = new SearchQueryFactory();
     }
@@ -24,6 +26,9 @@ class Search
     #[GQL\Query(name: 'search', type: 'SearchResult!')]
     public function search(SearchInput $input): SearchResult
     {
+        if ($input->urlBasePath !== null) {
+            $this->urlRewriteContext->setBasePath($input->urlBasePath);
+        }
         $query = $this->factory->create($input);
         try {
             return $this->search->search($query);

--- a/test/Query/MoreLikeThisTest.php
+++ b/test/Query/MoreLikeThisTest.php
@@ -7,6 +7,7 @@ namespace Atoolo\GraphQL\Search\Test\Query;
 use Atoolo\GraphQL\Search\Input\MoreLikeThisInput;
 use Atoolo\GraphQL\Search\Query\MoreLikeThis;
 use Atoolo\Resource\ResourceLanguage;
+use Atoolo\Rewrite\Service\UrlRewriteContext;
 use Atoolo\Search\Dto\Search\Query\MoreLikeThisQuery;
 use Atoolo\Search\Dto\Search\Result\SearchResult;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -19,6 +20,7 @@ class MoreLikeThisTest extends TestCase
     {
         $input = new MoreLikeThisInput();
         $input->id = '123';
+        $input->urlBasePath = '/test';
 
         $query = new MoreLikeThisQuery(
             id: '123',
@@ -31,7 +33,11 @@ class MoreLikeThisTest extends TestCase
             ->with($query)
             ->willReturn($this->createMock(SearchResult::class));
 
-        $select = new MoreLikeThis($searcher);
+        $urlRewriteContext = $this->createMock(UrlRewriteContext::class);
+        $urlRewriteContext->expects($this->once())
+            ->method('setBasePath')
+            ->with('/test');
+        $select = new MoreLikeThis($searcher, $urlRewriteContext);
         $select->moreLikeThis($input);
     }
 }

--- a/test/Query/SearchTest.php
+++ b/test/Query/SearchTest.php
@@ -6,6 +6,7 @@ namespace Atoolo\GraphQL\Search\Test\Query;
 
 use Atoolo\GraphQL\Search\Input\SearchInput;
 use Atoolo\GraphQL\Search\Query\Search;
+use Atoolo\Rewrite\Service\UrlRewriteContext;
 use Atoolo\Search\Dto\Search\Query\SearchQueryBuilder;
 use Atoolo\Search\Dto\Search\Result\SearchResult;
 use GraphQL\Error\UserError;
@@ -19,6 +20,7 @@ class SearchTest extends TestCase
     {
         $input = new SearchInput();
         $input->text = 'query';
+        $input->urlBasePath = '/test';
 
         $builder = new SearchQueryBuilder();
         $query = $builder
@@ -31,7 +33,12 @@ class SearchTest extends TestCase
             ->with($query)
             ->willReturn($this->createMock(SearchResult::class));
 
-        $select = new Search($searcher);
+        $urlRewriteContext = $this->createMock(UrlRewriteContext::class);
+        $urlRewriteContext->expects($this->once())
+            ->method('setBasePath')
+            ->with('/test');
+
+        $select = new Search($searcher, $urlRewriteContext);
         $select->search($input);
     }
 
@@ -45,7 +52,9 @@ class SearchTest extends TestCase
             ->method('search')
             ->willThrowException(new \Exception('test'));
 
-        $select = new Search($searcher);
+        $urlRewriteContext = $this->createMock(UrlRewriteContext::class);
+
+        $select = new Search($searcher, $urlRewriteContext);
 
         $this->expectException(UserError::class);
         $select->search($input);


### PR DESCRIPTION
Some rewriters require the URL of the page from which the GraphQL query was sent. This information is transmitted via `baseUrlPath` and passed to the UrlRewriteContext.