### PR TITLE
feat: search context

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,12 +7,13 @@ services:
     public: true
     arguments:
       - '@atoolo_search.search'
-      - '@atoolo_rewrite.url_rewrite_context'
+      - '@atoolo_graphql_search.query_context_dispatcher'
 
   Atoolo\GraphQL\Search\Query\MoreLikeThis:
     public: true
     arguments:
       - '@atoolo_search.more_like_this'
+      - '@atoolo_graphql_search.query_context_dispatcher'
 
   Atoolo\GraphQL\Search\Query\Suggest:
     public: true
@@ -28,6 +29,11 @@ services:
     public: true
     arguments:
       - '@atoolo_search.indexer.internal_resource_indexer'
+
+  atoolo_graphql_search.query_context_dispatcher:
+    class: Atoolo\GraphQL\Search\Query\Context\ContextDispatcher
+    arguments:
+      - '@atoolo_rewrite.url_rewrite_context'
 
   Atoolo\GraphQL\Search\Resolver\ClassNameTypeResolver:
     tags:

--- a/src/Input/MoreLikeThisInput.php
+++ b/src/Input/MoreLikeThisInput.php
@@ -15,8 +15,8 @@ class MoreLikeThisInput
     #[GQL\Field(type: "String!")]
     public string $id;
 
-    #[GQL\Field(type: "String")]
-    public ?string $urlBasePath = null;
+    #[GQL\Field(type: "SearchContextInput")]
+    public ?SearchContextInput $context = null;
 
     #[GQL\Field(type: "String")]
     public ?string $lang = null;

--- a/src/Input/SearchContextInput.php
+++ b/src/Input/SearchContextInput.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Input;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @codeCoverageIgnore
+ */
+#[GQL\Input(name: "SearchContextInput")]
+class SearchContextInput
+{
+    #[GQL\Field(type: "String")]
+    public ?string $urlBasePath = null;
+
+    #[GQL\Field(type: "SearchContextOptionsInput")]
+    public ?SearchContextOptionsInput $options = null;
+
+}

--- a/src/Input/SearchContextOptionsInput.php
+++ b/src/Input/SearchContextOptionsInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Input;
+
+use Overblog\GraphQLBundle\Annotation as GQL;
+
+/**
+ * @codeCoverageIgnore
+ */
+#[GQL\Input(name: "SearchContextOptionsInput")]
+class SearchContextOptionsInput
+{
+    #[GQL\Field(type: "Boolean")]
+    public ?bool $sameNavigation = null;
+}

--- a/src/Input/SearchInput.php
+++ b/src/Input/SearchInput.php
@@ -26,8 +26,8 @@ class SearchInput
     #[GQL\Field(type: "String")]
     public ?string $lang = null;
 
-    #[GQL\Field(type: "String")]
-    public ?string $urlBasePath = null;
+    #[GQL\Field(type: "SearchContextInput")]
+    public ?SearchContextInput $context = null;
 
     #[GQL\Field(type: "QueryOperator")]
     public ?QueryOperator $defaultQueryOperator = null;

--- a/src/Query/Context/ContextDispatcher.php
+++ b/src/Query/Context/ContextDispatcher.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Query\Context;
+
+use Atoolo\GraphQL\Search\Input\SearchContextInput;
+use Atoolo\Rewrite\Service\UrlRewriteContext;
+
+class ContextDispatcher
+{
+    public function __construct(
+        private readonly UrlRewriteContext $urlRewriteContext,
+    ) {}
+
+    public function dispatch(SearchContextInput $context): void
+    {
+        if ($context->urlBasePath !== null) {
+            $this->urlRewriteContext->setBasePath($context->urlBasePath);
+        }
+    }
+}

--- a/src/Query/MoreLikeThis.php
+++ b/src/Query/MoreLikeThis.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Query;
 
 use Atoolo\GraphQL\Search\Input\MoreLikeThisInput;
-use Atoolo\Rewrite\Service\UrlRewriteContext;
+use Atoolo\GraphQL\Search\Query\Context\ContextDispatcher;
 use Atoolo\Search\Dto\Search\Result\SearchResult;
 use Overblog\GraphQLBundle\Annotation as GQL;
 
@@ -16,7 +16,7 @@ class MoreLikeThis
 
     public function __construct(
         private readonly \Atoolo\Search\MoreLikeThis $moreLikeThis,
-        private readonly UrlRewriteContext $urlRewriteContext,
+        private readonly ContextDispatcher $contextDispatcher,
     ) {
         $this->factory = new MoreLikeThisQueryFactory();
     }
@@ -24,8 +24,8 @@ class MoreLikeThis
     #[GQL\Query(name: 'moreLikeThis', type: 'SearchResult!')]
     public function moreLikeThis(MoreLikeThisInput $input): SearchResult
     {
-        if ($input->urlBasePath !== null) {
-            $this->urlRewriteContext->setBasePath($input->urlBasePath);
+        if ($input->context !== null) {
+            $this->contextDispatcher->dispatch($input->context);
         }
         $query = $this->factory->create($input);
         return $this->moreLikeThis->moreLikeThis($query);

--- a/src/Query/Search.php
+++ b/src/Query/Search.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Query;
 
 use Atoolo\GraphQL\Search\Input\SearchInput;
-use Atoolo\Rewrite\Service\UrlRewriteContext;
+use Atoolo\GraphQL\Search\Query\Context\ContextDispatcher;
 use Atoolo\Search\Dto\Search\Result\SearchResult;
 use Exception;
 use Overblog\GraphQLBundle\Annotation as GQL;
@@ -18,7 +18,7 @@ class Search
 
     public function __construct(
         private readonly \Atoolo\Search\Search $search,
-        private readonly UrlRewriteContext $urlRewriteContext,
+        private readonly ContextDispatcher $contextDispatcher,
     ) {
         $this->factory = new SearchQueryFactory();
     }
@@ -26,8 +26,8 @@ class Search
     #[GQL\Query(name: 'search', type: 'SearchResult!')]
     public function search(SearchInput $input): SearchResult
     {
-        if ($input->urlBasePath !== null) {
-            $this->urlRewriteContext->setBasePath($input->urlBasePath);
+        if ($input->context !== null) {
+            $this->contextDispatcher->dispatch($input->context);
         }
         $query = $this->factory->create($input);
         try {

--- a/test/Query/Context/ContextDispatcherTest.php
+++ b/test/Query/Context/ContextDispatcherTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Test\Query\Context;
+
+use Atoolo\GraphQL\Search\Input\SearchContextInput;
+use Atoolo\GraphQL\Search\Query\Context\ContextDispatcher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContextDispatcher::class)]
+class ContextDispatcherTest extends TestCase
+{
+    public function testDispatch(): void
+    {
+        $context = new SearchContextInput();
+        $context->urlBasePath = '/test';
+
+        $urlRewriteContext = $this->createMock(\Atoolo\Rewrite\Service\UrlRewriteContext::class);
+        $urlRewriteContext->expects($this->once())
+            ->method('setBasePath')
+            ->with('/test');
+
+        $dispatcher = new ContextDispatcher($urlRewriteContext);
+        $dispatcher->dispatch($context);
+    }
+}

--- a/test/Query/MoreLikeThisTest.php
+++ b/test/Query/MoreLikeThisTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Test\Query;
 
 use Atoolo\GraphQL\Search\Input\MoreLikeThisInput;
+use Atoolo\GraphQL\Search\Input\SearchContextInput;
+use Atoolo\GraphQL\Search\Query\Context\ContextDispatcher;
 use Atoolo\GraphQL\Search\Query\MoreLikeThis;
 use Atoolo\Resource\ResourceLanguage;
-use Atoolo\Rewrite\Service\UrlRewriteContext;
 use Atoolo\Search\Dto\Search\Query\MoreLikeThisQuery;
 use Atoolo\Search\Dto\Search\Result\SearchResult;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -20,7 +21,9 @@ class MoreLikeThisTest extends TestCase
     {
         $input = new MoreLikeThisInput();
         $input->id = '123';
-        $input->urlBasePath = '/test';
+        $context = new SearchContextInput();
+        $context->urlBasePath = '/test';
+        $input->context = $context;
 
         $query = new MoreLikeThisQuery(
             id: '123',
@@ -33,11 +36,11 @@ class MoreLikeThisTest extends TestCase
             ->with($query)
             ->willReturn($this->createMock(SearchResult::class));
 
-        $urlRewriteContext = $this->createMock(UrlRewriteContext::class);
-        $urlRewriteContext->expects($this->once())
-            ->method('setBasePath')
-            ->with('/test');
-        $select = new MoreLikeThis($searcher, $urlRewriteContext);
+        $contextDispatcher = $this->createMock(ContextDispatcher::class);
+        $contextDispatcher->expects($this->once())
+            ->method('dispatch');
+
+        $select = new MoreLikeThis($searcher, $contextDispatcher);
         $select->moreLikeThis($input);
     }
 }


### PR DESCRIPTION
In some cases, context information is required, e.g. from the current page for which the GraphQL query is being executed.