### PR TITLE
fix(teaser): fix feature getter name in teaser resolvers

### DIFF
--- a/src/Resolver/Teaser/ArticleTeaserResolver.php
+++ b/src/Resolver/Teaser/ArticleTeaserResolver.php
@@ -62,7 +62,7 @@ class ArticleTeaserResolver implements Resolver
     /**
      * @return TeaserFeature[]
      */
-    public function getTeaserFeatures(
+    public function getFeatures(
         ArticleTeaser $teaser,
         ArgumentInterface $args,
     ): array {

--- a/src/Resolver/Teaser/MediaTeaserResolver.php
+++ b/src/Resolver/Teaser/MediaTeaserResolver.php
@@ -53,7 +53,7 @@ class MediaTeaserResolver implements Resolver
     /**
      * @return TeaserFeature[]
      */
-    public function getTeaserFeatures(
+    public function getFeatures(
         MediaTeaser $teaser,
         ArgumentInterface $args,
     ): array {

--- a/src/Resolver/Teaser/NewsTeaserResolver.php
+++ b/src/Resolver/Teaser/NewsTeaserResolver.php
@@ -62,7 +62,7 @@ class NewsTeaserResolver implements Resolver
     /**
      * @return TeaserFeature[]
      */
-    public function getTeaserFeatures(
+    public function getFeatures(
         NewsTeaser $teaser,
         ArgumentInterface $args,
     ): array {

--- a/test/Resolver/Teaser/ArticleTeaserResolverTest.php
+++ b/test/Resolver/Teaser/ArticleTeaserResolverTest.php
@@ -139,7 +139,7 @@ class ArticleTeaserResolverTest extends TestCase
         $this->resolver->getKicker($teaser, $args);
     }
 
-    public function testGetActions(): void
+    public function testGetFeatures(): void
     {
         $this->teaserFeatureResolver->expects($this->once())
             ->method('getTeaserFeatures');
@@ -150,6 +150,6 @@ class ArticleTeaserResolverTest extends TestCase
             $this->createStub(Resource::class),
         );
         $args = $this->createStub(ArgumentInterface::class);
-        $this->resolver->getTeaserFeatures($teaser, $args);
+        $this->resolver->getFeatures($teaser, $args);
     }
 }

--- a/test/Resolver/Teaser/MediaTeaserResolverTest.php
+++ b/test/Resolver/Teaser/MediaTeaserResolverTest.php
@@ -121,7 +121,7 @@ class MediaTeaserResolverTest extends TestCase
         $this->mediaTeaserResolver->getKicker($teaser, $args);
     }
 
-    public function testGetActions(): void
+    public function testGetFeatures(): void
     {
         $this->teaserFeatureResolver->expects($this->once())
             ->method('getTeaserFeatures');
@@ -134,6 +134,6 @@ class MediaTeaserResolverTest extends TestCase
             $this->createStub(Resource::class),
         );
         $args = $this->createStub(ArgumentInterface::class);
-        $this->mediaTeaserResolver->getTeaserFeatures($teaser, $args);
+        $this->mediaTeaserResolver->getFeatures($teaser, $args);
     }
 }

--- a/test/Resolver/Teaser/NewsTeaserResolverTest.php
+++ b/test/Resolver/Teaser/NewsTeaserResolverTest.php
@@ -139,7 +139,7 @@ class NewsTeaserResolverTest extends TestCase
         $this->resolver->getKicker($teaser, $args);
     }
 
-    public function testGetActions(): void
+    public function testGetFeatures(): void
     {
         $this->teaserFeatureResolver->expects($this->once())
             ->method('getTeaserFeatures');
@@ -150,6 +150,6 @@ class NewsTeaserResolverTest extends TestCase
             $this->createStub(Resource::class),
         );
         $args = $this->createStub(ArgumentInterface::class);
-        $this->resolver->getTeaserFeatures($teaser, $args);
+        $this->resolver->getFeatures($teaser, $args);
     }
 }


### PR DESCRIPTION
Unfortunately there was a small error in the [last PR](https://github.com/sitepark/atoolo-graphql-search-bundle/pull/81). The getter `getTeaserFeature` inside `ArticleTeaserResolver` etc. should be called `getFeatures` since the field is also called `features`. 