### PR TITLE
feat: added static source to Image

### DIFF
--- a/config/graphql/types/Other.type.yml
+++ b/config/graphql/types/Other.type.yml
@@ -114,6 +114,7 @@ Image:
       original: { type: "ImageSource!" }
       characteristic: { type: "ImageCharacteristic" }
       sources: { type: "[ImageSource!]!" }
+      static: { type: "ImageSource!" }
 
 ImageSource:
   type: "object"

--- a/src/Types/Image.php
+++ b/src/Types/Image.php
@@ -21,6 +21,7 @@ class Image extends Asset
         public readonly ?ImageSource $original,
         public readonly ?ImageCharacteristic $characteristic,
         public readonly array $sources,
+        public readonly ?ImageSource $static,
     ) {
         parent::__construct($copyright, $copyrightDetails, $caption, $description);
     }

--- a/test/Factory/ImageFactoryTest.php
+++ b/test/Factory/ImageFactoryTest.php
@@ -106,6 +106,13 @@ class ImageFactoryTest extends TestCase
                     mediaQuery: null,
                 ),
             ],
+            static: new ImageSource(
+                variant: 'teaser',
+                url: '/some_image_url.first.png',
+                width: 400,
+                height: 300,
+                mediaQuery: '(min-width: 1920px)',
+            ),
         );
         $this->assertEquals(
             $expectedImage,
@@ -172,8 +179,14 @@ class ImageFactoryTest extends TestCase
                 mediaQuery: null,
             ),
             characteristic: ImageCharacteristic::NORMAL,
-            sources: [
-            ],
+            sources: [],
+            static: new ImageSource(
+                variant: 'original',
+                url: '/some_image_url.original.png',
+                width: 4000,
+                height: 3000,
+                mediaQuery: null,
+            ),
         );
         $image = $this->factory->create($resource, 'teaser');
         $this->assertEquals(
@@ -223,8 +236,8 @@ class ImageFactoryTest extends TestCase
             alternativeText: null,
             original: null,
             characteristic: ImageCharacteristic::NORMAL,
-            sources: [
-            ],
+            sources: [],
+            static: null,
         );
         $image = $this->factory->create($resource, 'teaser');
         $this->assertEquals(
@@ -271,6 +284,7 @@ class ImageFactoryTest extends TestCase
                                     'width' => 400,
                                     'height' => 300,
                                     'mediaQuery' => '(min-width: 1920px)',
+                                    'static' => true,
                                 ],
                                 [
                                     'url' => '/some_image_url.second.png',

--- a/test/Resolver/ResolverMapRegistryTest.php
+++ b/test/Resolver/ResolverMapRegistryTest.php
@@ -132,6 +132,7 @@ class ResolverMapRegistryTest extends TestCase
             null,
             null,
             [],
+            null,
         );
 
         $type = $fn($image);


### PR DESCRIPTION
Adds a "static" `ImageSource` to `Image`. Static image sources act as a fallback in contexts where the sources with media queries (in the field `sources`) are not supported/necessary. 

This is standard tech in context of the sitekit but wasn't added to the graphql API yet, see the Redmine ticket below.

Refs: [#35315](https://redmine.sitepark.com/issues/35315)

