### PR TITLE
feat: added new field "staticImage" for static image source

### DIFF
--- a/config/graphql/types/Other.type.yml
+++ b/config/graphql/types/Other.type.yml
@@ -114,7 +114,10 @@ Image:
       original: { type: "ImageSource!" }
       characteristic: { type: "ImageCharacteristic" }
       sources: { type: "[ImageSource!]!" }
-      static: { type: "ImageSource!" }
+      static:
+        deprecationReason: "'static' might be a reserved keyword. Use field 'staticImage' instead"
+        type: "ImageSource!"
+      staticImage: { type: "ImageSource!" }
 
 ImageSource:
   type: "object"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -133,6 +133,13 @@ services:
     tags:
       - { name: 'atoolo_graphql_search.resolver' }
 
+  # Other resolvers
+
+  atoolo_graphql_search.resolver.asset.image_resolver:
+    class: Atoolo\GraphQL\Search\Resolver\Asset\ImageResolver
+    tags:
+      - { name: 'atoolo_graphql_search.resolver' }
+
   # Factories
 
   atoolo_graphql_search.factory.link_factory:

--- a/src/Resolver/Asset/ImageResolver.php
+++ b/src/Resolver/Asset/ImageResolver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Resolver\Asset;
+
+use Atoolo\GraphQL\Search\Resolver\Resolver;
+use Atoolo\GraphQL\Search\Types\Image;
+use Atoolo\GraphQL\Search\Types\ImageSource;
+
+class ImageResolver implements Resolver
+{
+    public function getStaticImage(
+        Image $image,
+    ): ?ImageSource {
+        return $image->static;
+    }
+}

--- a/test/Resolver/Asset/ImageResolverTest.php
+++ b/test/Resolver/Asset/ImageResolverTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Test\Resolver\Asset;
+
+use Atoolo\GraphQL\Search\Resolver\Asset\ImageResolver;
+use Atoolo\GraphQL\Search\Types\Image;
+use Atoolo\GraphQL\Search\Types\ImageSource;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ImageResolver::class)]
+class ImageResolverTest extends TestCase
+{
+    private ImageResolver $resolver;
+
+    /**
+     * @throws Exception
+     */
+    public function setUp(): void
+    {
+        $this->resolver = new ImageResolver();
+    }
+
+    public function testGetAsset(): void
+    {
+        $staticImageSource = new ImageSource('variant', '/static_image', 100, 100);
+        $image = new Image(
+            'copyright',
+            null,
+            'caption',
+            'description',
+            'alternativeText',
+            new ImageSource('variant', '/original_image', 100, 100),
+            null,
+            [],
+            $staticImageSource,
+        );
+        $result = $this->resolver->getStaticImage($image);
+        $this->assertEquals(
+            $staticImageSource,
+            $result,
+            'resolver should return the static image source of the image',
+        );
+    }
+}


### PR DESCRIPTION
Deprecates the field `static` for the graphql type `Image` and adds a new field `staticImage` that effectively acts as an alias.
This is because `static` might be a reserved keyword in consumer languages, e.g. TypeScript.

Generally, I don't think it's in the APIs responsibility to avoid all potential keywords in consumer languages. After all, consumers of a graphql API can always define a client-side alias for each field.
In this case however, `static` is a reserved keyword in TypeScript, which is probably one of the most used consumer languages for this graphql API, so I think we could make an exception here. 
