### PR TITLE
feat: sameNavigation Support for kicker

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,7 +36,7 @@ services:
   Atoolo\GraphQL\Search\Service\GraphQLOperationValidator:
     arguments:
       - '@Overblog\GraphQLBundle\Request\Executor'
-  
+
   Atoolo\GraphQL\Search\DependencyInjection\Cache\GraphQLOperationValidationCacheWarmer:
     arguments:
       - '@Atoolo\GraphQL\Search\Service\GraphQLOperationManager'
@@ -81,6 +81,7 @@ services:
     class: Atoolo\GraphQL\Search\Query\Context\ContextDispatcher
     arguments:
       - '@atoolo_rewrite.url_rewrite_context'
+      - '@atoolo_graphql_search.resolver.resource.resource_resolver_context'
 
   Atoolo\GraphQL\Search\Resolver\ClassNameTypeResolver:
     tags:
@@ -100,6 +101,9 @@ services:
       - { name: 'atoolo_graphql_search.resolver' }
 
   # Resource resolvers
+
+  atoolo_graphql_search.resolver.resource.resource_resolver_context:
+    class: Atoolo\GraphQL\Search\Resolver\Resource\ResourceResolverContext
 
   atoolo_graphql_search.resolver.resource.resource_resolver:
     class: Atoolo\GraphQL\Search\Resolver\Resource\ResourceResolver
@@ -126,6 +130,8 @@ services:
     class: Atoolo\GraphQL\Search\Resolver\Resource\ResourceKickerResolver
     arguments:
       - '@atoolo_resource.navigation_hierarchy_loader'
+      - '@atoolo_graphql_search.resolver.resource.resource_resolver_context'
+      - '@atoolo_resource.resource_loader'
     tags:
       - { name: 'atoolo_graphql_search.resolver' }
 

--- a/src/Query/Context/ContextDispatcher.php
+++ b/src/Query/Context/ContextDispatcher.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Atoolo\GraphQL\Search\Query\Context;
 
 use Atoolo\GraphQL\Search\Input\SearchContextInput;
+use Atoolo\GraphQL\Search\Resolver\Resource\ResourceResolverContext;
 use Atoolo\Rewrite\Service\UrlRewriteContext;
 
 class ContextDispatcher
 {
     public function __construct(
         private readonly UrlRewriteContext $urlRewriteContext,
+        private readonly ResourceResolverContext $resourceResolverContext,
     ) {}
 
     public function dispatch(SearchContextInput $context): void
@@ -20,11 +22,11 @@ class ContextDispatcher
         }
         if ($context->resourceLocation !== null) {
             $this->urlRewriteContext->setResourceLocation($context->resourceLocation);
+            $this->resourceResolverContext->setResourceLocation($context->resourceLocation);
         }
-        if ($context->options !== null) {
-            if ($context->options->sameNavigation !== null) {
-                $this->urlRewriteContext->setSameNavigation($context->options->sameNavigation);
-            }
+        if (($context->options !== null) && $context->options->sameNavigation !== null) {
+            $this->urlRewriteContext->setSameNavigation($context->options->sameNavigation);
+            $this->resourceResolverContext->setSameNavigation($context->options->sameNavigation);
         }
     }
 }

--- a/src/Resolver/Resource/ResourceKickerResolver.php
+++ b/src/Resolver/Resource/ResourceKickerResolver.php
@@ -8,25 +8,44 @@ use Atoolo\GraphQL\Search\Resolver\Resolver;
 use Atoolo\Resource\Resource;
 use Atoolo\Resource\ResourceHierarchyLoader;
 use Atoolo\Resource\ResourceHierarchyWalker;
+use Atoolo\Resource\ResourceLanguage;
+use Atoolo\Resource\ResourceLoader;
+use Atoolo\Resource\ResourceLocation;
 
 class ResourceKickerResolver implements Resolver
 {
     public function __construct(
         private readonly ResourceHierarchyLoader $hierarchyLoader,
+        private readonly ResourceResolverContext $resourceResolverContext,
+        private readonly ResourceLoader $resourceLoader,
     ) {}
 
     public function getKicker(
         Resource $resource,
     ): ?string {
-        $kickerText = $resource->data->getString(
-            'base.teaser.kicker',
-            $resource->data->getString('base.kicker'),
-        );
-        if (!empty($kickerText)) {
+
+        $kickerText = $this->getDirectKicker($resource);
+        if ($kickerText !== null) {
             return $kickerText;
         }
+
+        $changedNavigationParent = $this->getChangedNavigationParentResource($resource->lang);
+        if ($changedNavigationParent !== null) {
+            $kickerText = $this->getDirectKicker($changedNavigationParent);
+            if ($kickerText !== null) {
+                return $kickerText;
+            }
+        }
+
+        return $this->lookupKicker($changedNavigationParent ?? $resource);
+    }
+
+    private function lookupKicker(Resource $resource): ?string
+    {
+
         $walker = new ResourceHierarchyWalker($this->hierarchyLoader);
         $walker->init($resource);
+
         while ($parent = $walker->primaryParent()) {
             $kickerText = $parent->data->getString('base.kicker');
             if (!empty($kickerText)) {
@@ -34,5 +53,28 @@ class ResourceKickerResolver implements Resolver
             }
         }
         return null;
+    }
+
+    private function getChangedNavigationParentResource(ResourceLanguage $lang): ?Resource
+    {
+        if (!$this->resourceResolverContext->isSameNavigation()) {
+            return null;
+        }
+        $foreignResourceLocation = $this->resourceResolverContext->getResourceLocation();
+        if ($foreignResourceLocation === null) {
+            return null;
+        }
+
+        return $this->resourceLoader->load(ResourceLocation::of($foreignResourceLocation, $lang));
+    }
+
+    private function getDirectKicker(
+        Resource $resource,
+    ): ?string {
+        $kickerText = $resource->data->getString(
+            'base.teaser.kicker',
+            $resource->data->getString('base.kicker'),
+        );
+        return !empty($kickerText) ? $kickerText : null;
     }
 }

--- a/src/Resolver/Resource/ResourceResolverContext.php
+++ b/src/Resolver/Resource/ResourceResolverContext.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Resolver\Resource;
+
+class ResourceResolverContext
+{
+    private ?string $resourceLocation = null;
+
+    private bool $sameNavigation = false;
+
+    public function setResourceLocation(string $resourceLocation): void
+    {
+        $this->resourceLocation = $resourceLocation;
+    }
+
+    public function getResourceLocation(): ?string
+    {
+        return $this->resourceLocation;
+    }
+
+    public function setSameNavigation(bool $sameNavigation): void
+    {
+        $this->sameNavigation = $sameNavigation;
+    }
+
+    public function isSameNavigation(): bool
+    {
+        return $this->sameNavigation;
+    }
+}

--- a/test/Query/Context/ContextDispatcherTest.php
+++ b/test/Query/Context/ContextDispatcherTest.php
@@ -7,6 +7,7 @@ namespace Atoolo\GraphQL\Search\Test\Query\Context;
 use Atoolo\GraphQL\Search\Input\SearchContextInput;
 use Atoolo\GraphQL\Search\Input\SearchContextOptionsInput;
 use Atoolo\GraphQL\Search\Query\Context\ContextDispatcher;
+use Atoolo\GraphQL\Search\Resolver\Resource\ResourceResolverContext;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
@@ -31,7 +32,13 @@ class ContextDispatcherTest extends TestCase
             ->method('setResourceLocation')
             ->with('/test.php');
 
-        $dispatcher = new ContextDispatcher($urlRewriteContext);
+        $resourceResolverContext = $this->createMock(ResourceResolverContext::class);
+        $resourceResolverContext->expects($this->once())
+            ->method('setResourceLocation')
+            ->with('/test.php');
+
+
+        $dispatcher = new ContextDispatcher($urlRewriteContext, $resourceResolverContext);
         $dispatcher->dispatch($context);
     }
 
@@ -48,7 +55,9 @@ class ContextDispatcherTest extends TestCase
             ->method('setBasePath')
             ->with('/test');
 
-        $dispatcher = new ContextDispatcher($urlRewriteContext);
+        $resourceResolverContext = $this->createMock(ResourceResolverContext::class);
+
+        $dispatcher = new ContextDispatcher($urlRewriteContext, $resourceResolverContext);
         $dispatcher->dispatch($context);
     }
 
@@ -64,7 +73,12 @@ class ContextDispatcherTest extends TestCase
             ->method('setSameNavigation')
             ->with(true);
 
-        $dispatcher = new ContextDispatcher($urlRewriteContext);
+        $resourceResolverContext = $this->createMock(ResourceResolverContext::class);
+        $resourceResolverContext->expects($this->once())
+            ->method('setSameNavigation')
+            ->with(true);
+
+        $dispatcher = new ContextDispatcher($urlRewriteContext, $resourceResolverContext);
         $dispatcher->dispatch($context);
     }
 }

--- a/test/Resolver/Resource/ResourceResolverContextTest.php
+++ b/test/Resolver/Resource/ResourceResolverContextTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\GraphQL\Search\Test\Resolver\Resource;
+
+use Atoolo\GraphQL\Search\Resolver\Resource\ResourceResolverContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResourceResolverContext::class)]
+class ResourceResolverContextTest extends TestCase
+{
+    public function testSetAndGetResourceLocation(): void
+    {
+        $context = new ResourceResolverContext();
+        $context->setResourceLocation('/example/location.php');
+
+        $this->assertSame('/example/location.php', $context->getResourceLocation());
+    }
+
+    public function testSetAndIsSameNavigation(): void
+    {
+        $context = new ResourceResolverContext();
+        $context->setSameNavigation(true);
+
+        $this->assertTrue($context->isSameNavigation());
+    }
+}

--- a/test/resources/ArticleTeaserResolver/changed-navigation-parent.php
+++ b/test/resources/ArticleTeaserResolver/changed-navigation-parent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Atoolo\GraphQL\Search\Test\TestResourceFactory;
+
+return TestResourceFactory::create([
+    'url' => '/changed-navigation-parent.php',
+    'id' => 'changed-navigation-parent',
+    'name' => 'changed-navigation-parent',
+    'locale' => 'en_US',
+    'base' => [
+        'kicker' => 'Changed-Navigation-Parent-Kicker',
+    ],
+]);


### PR DESCRIPTION
The following context can be specified with the GraphQL search:

```graphql
context :{
   resourceLocation: "/musterseiten/artikeltypen/index.php"
   options: {
      sameNavigation: false
    }
}
```

This ensures that a p-parameter is appended to the URL of the result teaser, which can be used to "rehang" the navigation of the article. This changes the determination of the kicker if it has to be determined via navigation.

Until now, this logic has not been taken into account in the `ResourceKickerResolver`. This will be rectified with this merge request.