### PR TITLE
feat: added parameter "minHitCount"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-sysvsem": "*",
         "atoolo/resource-bundle": "^1.5",
         "atoolo/rewrite-bundle": "^1.2",
-        "atoolo/search-bundle": "^1.13",
+        "atoolo/search-bundle": "^1.14",
         "overblog/graphql-bundle": "^1.0",
         "symfony/config": "^6.3 || ^7.0",
         "symfony/dependency-injection": "^6.3 || ^7.0",

--- a/src/Input/SuggestInput.php
+++ b/src/Input/SuggestInput.php
@@ -29,4 +29,7 @@ class SuggestInput
 
     #[GQL\Field(type: "Boolean")]
     public ?bool $archive = null;
+
+    #[GQL\Field(type: "Int")]
+    public ?int $minHitCount = null;
 }

--- a/src/Query/SuggestQueryFactory.php
+++ b/src/Query/SuggestQueryFactory.php
@@ -31,6 +31,7 @@ class SuggestQueryFactory
             $filterList,
             $input->limit ?? 10,
             $input->archive ?? false,
+            $input->minHitCount ?? 0,
         );
     }
 }


### PR DESCRIPTION
Added parameter `minHitCount` to the suggest query to control the minimum number of hits a suggestion must have to be part of the result.

See also: https://github.com/sitepark/atoolo-search-bundle/pull/46